### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -289,13 +289,13 @@ impl FuncCall {
         if let Some(_) = self.class_name {
             return None;
         }
-        if constants::AV_RULES.iter().any(|i| *i == &self.name) {
+        if constants::AV_RULES.iter().any(|i| *i == self.name) {
             return Some(BuiltIns::AvRule);
         }
-        if &self.name == constants::FILE_CONTEXT_FUNCTION_NAME {
+        if self.name == constants::FILE_CONTEXT_FUNCTION_NAME {
             return Some(BuiltIns::FileContext);
         }
-        if &self.name == constants::DOMTRANS_FUNCTION_NAME {
+        if self.name == constants::DOMTRANS_FUNCTION_NAME {
             return Some(BuiltIns::DomainTransition);
         }
         None

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -286,7 +286,7 @@ impl FuncCall {
     }
 
     pub fn check_builtin(&self) -> Option<BuiltIns> {
-        if let Some(_) = self.class_name {
+        if self.class_name.is_some() {
             return None;
         }
         if constants::AV_RULES.iter().any(|i| *i == self.name) {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,7 +23,7 @@ impl fmt::Display for HLLString {
 impl HLLString {
     pub fn new(string: String, range: Range<usize>) -> Self {
         HLLString {
-            string: string,
+            string,
             range: Some(range),
         }
     }
@@ -128,10 +128,7 @@ pub struct PolicyFile {
 
 impl PolicyFile {
     pub fn new(policy: Policy, file: SimpleFile<String, String>) -> Self {
-        PolicyFile {
-            policy: policy,
-            file: file,
-        }
+        PolicyFile { policy, file }
     }
 }
 
@@ -142,7 +139,7 @@ pub struct Policy {
 
 impl Policy {
     pub fn new(exprs: Vec<Expression>) -> Policy {
-        Policy { exprs: exprs }
+        Policy { exprs }
     }
 }
 
@@ -208,8 +205,8 @@ pub struct TypeDecl {
 impl TypeDecl {
     pub fn new(name: HLLString, inherits: Vec<HLLString>, exprs: Vec<Expression>) -> TypeDecl {
         TypeDecl {
-            name: name,
-            inherits: inherits,
+            name,
+            inherits,
             is_virtual: false,
             expressions: exprs,
             annotations: Annotations::new(),
@@ -344,7 +341,7 @@ pub struct Annotation {
 impl Annotation {
     pub fn new(name: HLLString) -> Self {
         Annotation {
-            name: name,
+            name,
             arguments: Vec::new(),
         }
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -151,9 +151,8 @@ pub enum Expression {
 
 impl Expression {
     pub fn set_class_name_if_decl(&mut self, name: HLLString) {
-        match self {
-            Expression::Decl(Declaration::Func(d)) => d.class_name = Some(name),
-            _ => (),
+        if let Expression::Decl(Declaration::Func(d)) = self {
+            d.class_name = Some(name)
         }
     }
 
@@ -287,9 +286,8 @@ impl FuncCall {
     }
 
     pub fn check_builtin(&self) -> Option<BuiltIns> {
-        match self.class_name {
-            Some(_) => return None,
-            None => (),
+        if let Some(_) = self.class_name {
+            return None;
         }
         if constants::AV_RULES.iter().any(|i| *i == &self.name) {
             return Some(BuiltIns::AvRule);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -613,7 +613,7 @@ fn check_non_virtual_inheritance(types: &TypeMap) -> Result<(), HLLErrors> {
 // 1. All types have at least one parent
 // 2. All listed parents are themselves types (or "domain" or "resource")
 // 3. No cycles exist
-fn organize_type_map<'a>(types: &'a TypeMap) -> Result<Vec<&'a TypeInfo>, HLLErrors> {
+fn organize_type_map(types: &TypeMap) -> Result<Vec<&TypeInfo>, HLLErrors> {
     let mut tmp_types: BTreeMap<&String, &TypeInfo> = types.iter().collect();
 
     let mut out: Vec<&TypeInfo> = Vec::new();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -25,9 +25,9 @@ pub fn compile_rules_one_file<'a>(
 ) -> Result<BTreeSet<ValidatedStatement<'a>>, HLLErrors> {
     do_rules_pass(
         &p.policy.exprs,
-        &type_map,
-        &func_map,
-        &classlist,
+        type_map,
+        func_map,
+        classlist,
         None,
         &p.file,
     )
@@ -42,7 +42,7 @@ pub fn generate_sexp(
     let type_decl_list = organize_type_map(type_map)?;
     // TODO: The rest of compilation
     let cil_types = type_list_to_sexp(type_decl_list, type_map);
-    let headers = generate_cil_headers(&classlist);
+    let headers = generate_cil_headers(classlist);
     let cil_rules = rules_list_to_sexp(policy_rules);
     let cil_macros = func_map_to_sexp(func_map)?;
     let sid_statements =
@@ -206,7 +206,7 @@ pub fn validate_functions<'a, 'b>(
     let mut errors = HLLErrors::new();
     for function in functions.values_mut() {
         match function.validate_body(
-            &functions_copy,
+            functions_copy,
             types,
             class_perms,
             function.declaration_file,
@@ -259,7 +259,7 @@ fn find_cycles_or_bad_types(
         let mut new_visited_types = visited_types.clone();
         new_visited_types.insert(type_to_check.name.as_ref());
 
-        match find_cycles_or_bad_types(&parent_ti, types, new_visited_types) {
+        match find_cycles_or_bad_types(parent_ti, types, new_visited_types) {
             Ok(()) => (),
             Err(e) => ret.append(e),
         }
@@ -271,7 +271,7 @@ fn find_cycles_or_bad_types(
 fn generate_type_no_parent_errors(missed_types: Vec<&TypeInfo>, types: &TypeMap) -> HLLErrors {
     let mut ret = HLLErrors::new();
     for t in &missed_types {
-        match find_cycles_or_bad_types(&t, types, HashSet::new()) {
+        match find_cycles_or_bad_types(t, types, HashSet::new()) {
             Ok(()) => {
                 ret.add_error(HLLInternalError {});
                 return ret;
@@ -465,7 +465,7 @@ where
                 types,
                 associate,
                 inherited.parent,
-                &dom_info,
+                dom_info,
             ) {
                 Ok(()) => {}
                 Err(e) => errors.append(e),
@@ -525,10 +525,10 @@ fn inherit_annotations<'a>(
             .iter()
             .map(|a| InheritedAnnotation {
                 annotation: a,
-                parent: Some(&dom_info),
+                parent: Some(dom_info),
             })
             .chain(inherited_annotations.into_iter().map(|mut a| {
-                a.parent = Some(&dom_info);
+                a.parent = Some(dom_info);
                 a
             }))
             .collect()
@@ -738,7 +738,7 @@ fn get_rules_vec_for_type(ti: &TypeInfo, s: sexp::Sexp, type_map: &TypeMap) -> V
         ret.push(list(&[
             atom_s("roletype"),
             atom_s(role_assoc),
-            atom_s(&ti.name.as_ref()),
+            atom_s(ti.name.as_ref()),
         ]));
     }
 
@@ -746,7 +746,7 @@ fn get_rules_vec_for_type(ti: &TypeInfo, s: sexp::Sexp, type_map: &TypeMap) -> V
         ret.push(list(&[
             atom_s("typeattributeset"),
             atom_s(i.as_ref()),
-            list(&[atom_s(&ti.name.as_ref())]),
+            list(&[atom_s(ti.name.as_ref())]),
         ]));
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -158,7 +158,7 @@ pub fn get_built_in_types_map() -> TypeMap {
 }
 
 pub fn build_func_map<'a>(
-    exprs: &'a Vec<Expression>,
+    exprs: &'a [Expression],
     types: &'a TypeMap,
     parent_type: Option<&'a TypeInfo>,
     file: &'a SimpleFile<String, String>,
@@ -660,7 +660,7 @@ fn organize_type_map<'a>(types: &'a TypeMap) -> Result<Vec<&'a TypeInfo>, HLLErr
 }
 
 fn do_rules_pass<'a>(
-    exprs: &'a Vec<Expression>,
+    exprs: &'a [Expression],
     types: &'a TypeMap,
     funcs: &'a FunctionMap<'a>,
     class_perms: &ClassList<'a>,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -591,20 +591,17 @@ pub fn apply_annotations<'a>(
 fn check_non_virtual_inheritance(types: &TypeMap) -> Result<(), HLLErrors> {
     for t in types.values() {
         for parent in &t.inherits {
-            match types.get(&parent.to_string()) {
-                Some(p) => {
-                    if !p.is_virtual {
-                        return Err(HLLErrorItem::make_compile_or_internal_error(
-                            "Inheriting from a non-virtual type is not yet supported",
-                            t.declaration_file.as_ref(),
-                            parent.get_range(),
-                            "This type is not virtual",
-                        )
-                        .into());
-                    }
+            if let Some(p) = types.get(&parent.to_string()) {
+                if !p.is_virtual {
+                    return Err(HLLErrorItem::make_compile_or_internal_error(
+                        "Inheriting from a non-virtual type is not yet supported",
+                        t.declaration_file.as_ref(),
+                        parent.get_range(),
+                        "This type is not virtual",
+                    )
+                    .into());
                 }
-                None => (),
-            };
+            }
         }
     }
     Ok(())
@@ -717,11 +714,8 @@ fn do_rules_pass<'a>(
 fn type_list_to_sexp(type_list: Vec<&TypeInfo>, type_map: &TypeMap) -> Vec<sexp::Sexp> {
     let mut ret = Vec::new();
     for t in type_list {
-        match Option::<sexp::Sexp>::from(t) {
-            Some(s) => {
-                ret.extend(get_rules_vec_for_type(t, s, type_map));
-            }
-            None => (),
+        if let Some(s) = Option::<sexp::Sexp>::from(t) {
+            ret.extend(get_rules_vec_for_type(t, s, type_map));
         }
     }
     ret

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -23,14 +23,14 @@ pub fn compile_rules_one_file<'a>(
     type_map: &'a TypeMap,
     func_map: &'a FunctionMap<'a>,
 ) -> Result<BTreeSet<ValidatedStatement<'a>>, HLLErrors> {
-    Ok(do_rules_pass(
+    do_rules_pass(
         &p.policy.exprs,
         &type_map,
         &func_map,
         &classlist,
         None,
         &p.file,
-    )?)
+    )
 }
 
 pub fn generate_sexp(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -174,7 +174,7 @@ pub fn build_func_map<'a>(
             Declaration::Type(t) => {
                 let type_being_parsed = match types.get(&t.name.to_string()) {
                     Some(t) => t,
-                    None => Err(HLLErrorItem::Internal(HLLInternalError {}))?,
+                    None => return Err(HLLErrorItem::Internal(HLLInternalError {}).into()),
                 };
                 decl_map.extend(build_func_map(
                     &t.expressions,
@@ -296,7 +296,7 @@ fn create_synthetic_resource(
     global_exprs: &mut HashSet<Expression>,
 ) -> Result<HLLString, HLLErrorItem> {
     if !class.is_resource(types) {
-        Err(HLLCompileError::new(
+        return Err(HLLCompileError::new(
             "not a resource",
             dom_info
                 .declaration_file
@@ -304,7 +304,8 @@ fn create_synthetic_resource(
                 .ok_or(HLLErrorItem::Internal(HLLInternalError {}))?,
             class_string.get_range(),
             "This should not be a domain but a resource.",
-        ))?;
+        )
+        .into());
     }
 
     // Creates a synthetic resource declaration.
@@ -323,7 +324,7 @@ fn create_synthetic_resource(
         .iter_mut()
         .for_each(|e| e.set_class_name_if_decl(res_name.clone()));
     if !global_exprs.insert(Expression::Decl(Declaration::Type(Box::new(dup_res_decl)))) {
-        Err(HLLInternalError {})?;
+        return Err(HLLInternalError {}.into());
     }
     Ok(res_name)
 }
@@ -385,7 +386,7 @@ fn interpret_associate(
                     vec![Argument::Var("this".into())],
                 ))));
                 if !local_exprs.insert(new_call) {
-                    Err(HLLErrorItem::Internal(HLLInternalError {}))?;
+                    return Err(HLLErrorItem::Internal(HLLInternalError {}).into());
                 }
             }
         }
@@ -692,7 +693,7 @@ fn do_rules_pass<'a>(
             Expression::Decl(Declaration::Type(t)) => {
                 let type_being_parsed = match types.get(&t.name.to_string()) {
                     Some(t) => t,
-                    None => Err(HLLErrorItem::Internal(HLLInternalError {}))?,
+                    None => return Err(HLLErrorItem::Internal(HLLInternalError {}).into()),
                 };
                 match do_rules_pass(
                     &t.expressions,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -562,7 +562,7 @@ pub fn apply_annotations<'a>(
 
     match associate_exprs
         .into_iter()
-        .filter(|(_, v)| v.len() != 0)
+        .filter(|(_, v)| !v.is_empty())
         .map(|(k, v)| {
             // TODO: Avoid cloning all expressions.
             let mut new_domain = types
@@ -575,7 +575,7 @@ pub fn apply_annotations<'a>(
             new_domain.expressions = v.into_iter().collect();
             Ok(Expression::Decl(Declaration::Type(Box::new(new_domain))))
         })
-        .chain(global_exprs.into_iter().map(|e| Ok(e)))
+        .chain(global_exprs.into_iter().map(Ok))
         .collect::<Result<_, HLLErrors>>()
     {
         Ok(r) => errors.into_result(r),
@@ -648,7 +648,7 @@ fn organize_type_map<'a>(types: &'a TypeMap) -> Result<Vec<&'a TypeInfo>, HLLErr
         if current_pass_types.is_empty() && !tmp_types.is_empty() {
             // We can't satify the parents for all types
             return Err(generate_type_no_parent_errors(
-                tmp_types.values().map(|t| *t).collect(),
+                tmp_types.values().copied().collect(),
                 types,
             ));
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
-pub const ALLOW_FUNCTION_NAME: &'static str = "allow";
-pub const DONTAUDIT_FUNCTION_NAME: &'static str = "dontaudit";
-pub const AUDITALLOW_FUNCTION_NAME: &'static str = "auditallow";
-pub const NEVERALLOW_FUNCTION_NAME: &'static str = "neverallow";
-pub const FILE_CONTEXT_FUNCTION_NAME: &'static str = "file_context";
-pub const DOMTRANS_FUNCTION_NAME: &'static str = "domain_transition";
+pub const ALLOW_FUNCTION_NAME: &str = "allow";
+pub const DONTAUDIT_FUNCTION_NAME: &str = "dontaudit";
+pub const AUDITALLOW_FUNCTION_NAME: &str = "auditallow";
+pub const NEVERALLOW_FUNCTION_NAME: &str = "neverallow";
+pub const FILE_CONTEXT_FUNCTION_NAME: &str = "file_context";
+pub const DOMTRANS_FUNCTION_NAME: &str = "domain_transition";
 
-pub const AV_RULES: &'static [&'static str] = &[
+pub const AV_RULES: &[&str] = &[
     ALLOW_FUNCTION_NAME,
     DONTAUDIT_FUNCTION_NAME,
     AUDITALLOW_FUNCTION_NAME,
     NEVERALLOW_FUNCTION_NAME,
 ];
 
-pub const BUILT_IN_TYPES: &'static [&'static str] = &[
+pub const BUILT_IN_TYPES: &[&str] = &[
     "domain",
     "resource",
     "path",

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,9 +139,9 @@ impl HLLParseError {
             file: SimpleFile::new(file_name, policy),
             diagnostic: match msg.range {
                 None => diagnostic,
-                Some(range) => diagnostic.with_labels(vec![
-                    Label::primary((), range.clone()).with_message(msg.help)
-                ]),
+                Some(range) => {
+                    diagnostic.with_labels(vec![Label::primary((), range).with_message(msg.help)])
+                }
             }
             .into(),
         }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -500,10 +500,7 @@ pub struct Sid<'a> {
 
 impl<'a> Sid<'a> {
     pub fn new(name: &'a str, context: Context<'a>) -> Self {
-        Sid {
-            name: name,
-            context: context,
-        }
+        Sid { name, context }
     }
 
     fn get_sid_statement(&self) -> Sexp {
@@ -552,10 +549,7 @@ impl From<&Class<'_>> for sexp::Sexp {
 
 impl<'a> Class<'a> {
     pub fn new(name: &'a str, perms: Vec<&'a str>) -> Self {
-        Class {
-            name: name,
-            perms: perms,
-        }
+        Class { name, perms }
     }
 
     pub fn contains_perm(&self, perm: &str) -> bool {
@@ -751,10 +745,10 @@ fn call_to_av_rule<'a>(
 
     Ok(AvRule {
         av_rule_flavor: flavor,
-        source: source,
-        target: target,
-        class: class,
-        perms: perms,
+        source,
+        target,
+        class,
+        perms,
     })
 }
 
@@ -904,8 +898,8 @@ fn call_to_fc_rules<'a>(
 
         ret.push(FileContextRule {
             regex_string: regex_string.clone(),
-            file_type: file_type,
-            context: context,
+            file_type,
+            context,
         });
     }
 
@@ -989,9 +983,9 @@ fn call_to_domain_transition<'a>(
     }
 
     Ok(DomtransRule {
-        source: source,
-        target: target,
-        executable: executable,
+        source,
+        target,
+        executable,
     })
 }
 
@@ -1128,11 +1122,11 @@ impl<'a> FunctionInfo<'a> {
         errors.into_result(FunctionInfo {
             name: funcdecl.name.to_string(),
             class: parent_type,
-            args: args,
+            args,
             original_body: &funcdecl.body,
             body: None,
-            declaration_file: declaration_file,
-            is_associated_call: is_associated_call,
+            declaration_file,
+            is_associated_call,
             decl: &funcdecl,
         })
     }
@@ -1224,7 +1218,7 @@ impl<'a> FunctionArgument<'a> {
         // TODO list parameters
 
         Ok(FunctionArgument {
-            param_type: param_type,
+            param_type,
             name: declared_arg.name.to_string(),
             is_list_param: declared_arg.is_list_param,
         })
@@ -1395,10 +1389,7 @@ impl ValidatedCall {
             args.push(arg.get_name_or_string()?.to_string()); // TODO: Handle lists
         }
 
-        Ok(ValidatedCall {
-            cil_name: cil_name,
-            args: args,
-        })
+        Ok(ValidatedCall { cil_name, args })
     }
 }
 
@@ -1478,9 +1469,9 @@ impl<'a> TypeInstance<'a> {
         };
 
         TypeInstance {
-            instance_value: instance_value,
+            instance_value,
             type_info: &ti,
-            file: file,
+            file,
         }
     }
 }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -667,7 +667,7 @@ fn call_to_av_rule<'a>(
         constants::DONTAUDIT_FUNCTION_NAME => AvRuleFlavor::Dontaudit,
         constants::AUDITALLOW_FUNCTION_NAME => AvRuleFlavor::Auditallow,
         constants::NEVERALLOW_FUNCTION_NAME => AvRuleFlavor::Neverallow,
-        _ => Err(HLLErrorItem::Internal(HLLInternalError {}))?,
+        _ => return Err(HLLErrorItem::Internal(HLLInternalError {}).into()),
     };
 
     let target_args = vec![
@@ -730,7 +730,7 @@ fn call_to_av_rule<'a>(
         .get_list()?;
 
     if args_iter.next().is_some() {
-        Err(HLLErrorItem::Internal(HLLInternalError {}))?;
+        return Err(HLLErrorItem::Internal(HLLInternalError {}).into());
     }
 
     for p in &perms {
@@ -973,7 +973,7 @@ fn call_to_domain_transition<'a>(
         .type_info;
 
     if args_iter.next().is_some() {
-        Err(HLLErrorItem::Internal(HLLInternalError {}))?;
+        return Err(HLLErrorItem::Internal(HLLInternalError {}).into());
     }
 
     Ok(DomtransRule {
@@ -1161,7 +1161,7 @@ impl TryFrom<&FunctionInfo<'_>> for sexp::Sexp {
             Sexp::List(f.args.iter().map(Sexp::from).collect()),
         ];
         match &f.body {
-            None => Err(HLLInternalError {})?,
+            None => return Err(HLLInternalError {}.into()),
             Some(statements) => {
                 for statement in statements {
                     match statement {
@@ -1571,7 +1571,7 @@ fn validate_argument<'a>(
             }
             let target_ti = match types.get(&target_argument.param_type.name.to_string()) {
                 Some(t) => t,
-                None => Err(HLLInternalError {})?,
+                None => return Err(HLLInternalError {}.into()),
             };
             let arg_typeinfo_vec = argument_to_typeinfo_vec(v, types, class_perms, args, file)?;
 

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -185,16 +185,13 @@ fn get_associate(
         }
     };
 
-    match args.next() {
-        Some(a) => {
-            return Err(HLLCompileError::new(
-                "Superfluous argument",
-                file,
-                a.get_range(),
-                "There must be only one argument.",
-            ))
-        }
-        None => {}
+    if let Some(a) = args.next() {
+        return Err(HLLCompileError::new(
+            "Superfluous argument",
+            file,
+            a.get_range(),
+            "There must be only one argument.",
+        ));
     }
 
     Ok(AnnotationInfo::Associate(Associated {
@@ -622,15 +619,12 @@ impl<'a> ClassList<'a> {
                 _ => None,
             };
 
-            match other_str {
-                Some(s) => {
-                    let hll_string = match class.get_range() {
-                        Some(range) => HLLString::new(s.to_string(), range),
-                        None => HLLString::from(s.to_string()),
-                    };
-                    return self.verify_permission(&hll_string, permission, file);
-                }
-                None => (),
+            if let Some(s) = other_str {
+                let hll_string = match class.get_range() {
+                    Some(range) => HLLString::new(s.to_string(), range),
+                    None => HLLString::from(s.to_string()),
+                };
+                return self.verify_permission(&hll_string, permission, file);
             }
 
             return Err(HLLCompileError::new(
@@ -997,16 +991,13 @@ fn check_associated_call(
     // Checks that annotation arguments match the expected signature.
     let mut annotation_args = annotation.arguments.iter();
 
-    match annotation_args.next() {
-        Some(a) => {
-            return Err(HLLCompileError::new(
-                "Superfluous argument",
-                file,
-                a.get_range(),
-                "@associated_call doesn't take argument.",
-            ))
-        }
-        None => {}
+    if let Some(a) = annotation_args.next() {
+        return Err(HLLCompileError::new(
+            "Superfluous argument",
+            file,
+            a.get_range(),
+            "@associated_call doesn't take argument.",
+        ));
     }
 
     // Checks that annotated functions match the expected signature.
@@ -1035,16 +1026,13 @@ fn check_associated_call(
             }
         }
     }
-    match func_args.next() {
-        Some(a) => {
-            return Err(HLLCompileError::new(
-                "Invalid method signature for @associated_call annotation: too much arguments",
-                file,
-                a.param_type.get_range(),
-                "Only one argument of type 'domain' is accepted.",
-            ));
-        }
-        None => {}
+    if let Some(a) = func_args.next() {
+        return Err(HLLCompileError::new(
+            "Invalid method signature for @associated_call annotation: too much arguments",
+            file,
+            a.param_type.get_range(),
+            "Only one argument of type 'domain' is accepted.",
+        ));
     }
 
     Ok(true)
@@ -1075,9 +1063,8 @@ impl<'a> FunctionInfo<'a> {
         let mut errors = HLLErrors::new();
 
         // All member functions automatically have "this" available as a reference to their type
-        match parent_type {
-            Some(parent_type) => args.push(FunctionArgument::new_this_argument(parent_type)),
-            None => (),
+        if let Some(parent_type) = parent_type {
+            args.push(FunctionArgument::new_this_argument(parent_type));
         }
 
         for a in &funcdecl.args {

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -575,7 +575,7 @@ impl<'a> ClassList<'a> {
     }
 
     pub fn generate_class_perm_cil(&self) -> Vec<Sexp> {
-        let mut ret: Vec<Sexp> = self.classes.values().map(|c| Sexp::from(c)).collect();
+        let mut ret: Vec<Sexp> = self.classes.values().map(Sexp::from).collect();
 
         let classorder = list(&[
             atom_s("classorder"),
@@ -1158,7 +1158,7 @@ impl TryFrom<&FunctionInfo<'_>> for sexp::Sexp {
         let mut macro_cil = vec![
             atom_s("macro"),
             atom_s(&f.get_cil_name()),
-            Sexp::List(f.args.iter().map(|a| Sexp::from(a)).collect()),
+            Sexp::List(f.args.iter().map(Sexp::from).collect()),
         ];
         match &f.body {
             None => Err(HLLInternalError {})?,
@@ -1270,7 +1270,7 @@ impl<'a> ValidatedStatement<'a> {
                         if in_resource {
                             Ok(call_to_fc_rules(c, types, class_perms, Some(args), file)?
                                 .into_iter()
-                                .map(|f| ValidatedStatement::FcRule(f))
+                                .map(ValidatedStatement::FcRule)
                                 .collect())
                         } else {
                             Err(HLLErrors::from(HLLErrorItem::Compile(
@@ -1689,8 +1689,8 @@ mod tests {
             "(sidorder (foo bar))",
         ];
         assert_eq!(rules.len(), cil_expected.len());
-        let mut iter = rules.iter().zip(cil_expected.iter());
-        while let Some(i) = iter.next() {
+        let iter = rules.iter().zip(cil_expected.iter());
+        for i in iter {
             assert_eq!(i.0.to_string(), i.1.to_string());
         }
     }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -154,7 +154,7 @@ impl From<&TypeInfo> for Option<sexp::Sexp> {
             Some(f) => f,
             None => return None,
         };
-        Some(list(&[atom_s(flavor), atom_s(&typeinfo.name.as_ref())]))
+        Some(list(&[atom_s(flavor), atom_s(typeinfo.name.as_ref())]))
     }
 }
 
@@ -740,7 +740,7 @@ fn call_to_av_rule<'a>(
     }
 
     for p in &perms {
-        class_perms.verify_permission(&class, &p, file)?;
+        class_perms.verify_permission(class, p, file)?;
     }
 
     Ok(AvRule {
@@ -1081,7 +1081,7 @@ impl<'a> FunctionInfo<'a> {
         }
 
         for a in &funcdecl.args {
-            match FunctionArgument::new(&a, types, Some(declaration_file)) {
+            match FunctionArgument::new(a, types, Some(declaration_file)) {
                 Ok(a) => args.push(a),
                 Err(e) => errors.add_error(e),
             }
@@ -1127,7 +1127,7 @@ impl<'a> FunctionInfo<'a> {
             body: None,
             declaration_file,
             is_associated_call,
-            decl: &funcdecl,
+            decl: funcdecl,
         })
     }
 
@@ -1446,7 +1446,7 @@ impl<'a> TypeInstance<'a> {
     fn get_range(&self) -> Option<Range<usize>> {
         match &self.instance_value {
             TypeValue::Str(s) => s.get_range(),
-            TypeValue::Vector(v) => HLLString::vec_to_range(&v),
+            TypeValue::Vector(v) => HLLString::vec_to_range(v),
             TypeValue::SEType(r) => r.clone(),
         }
     }
@@ -1470,7 +1470,7 @@ impl<'a> TypeInstance<'a> {
 
         TypeInstance {
             instance_value,
-            type_info: &ti,
+            type_info: ti,
             file,
         }
     }
@@ -1558,7 +1558,7 @@ impl<'a> ArgForValidation<'a> {
     fn get_range(&self) -> Option<Range<usize>> {
         match self {
             ArgForValidation::Var(s) => s.get_range(),
-            ArgForValidation::List(v) => HLLString::vec_to_range(&v),
+            ArgForValidation::List(v) => HLLString::vec_to_range(v),
             ArgForValidation::Quote(s) => s.get_range(),
         }
     }
@@ -1586,7 +1586,7 @@ fn validate_argument<'a>(
                 Some(t) => t,
                 None => Err(HLLInternalError {})?,
             };
-            let arg_typeinfo_vec = argument_to_typeinfo_vec(&v, types, class_perms, args, file)?;
+            let arg_typeinfo_vec = argument_to_typeinfo_vec(v, types, class_perms, args, file)?;
 
             for arg in arg_typeinfo_vec {
                 if !arg.is_child_or_actual_type(target_argument.param_type, types) {
@@ -1598,7 +1598,7 @@ fn validate_argument<'a>(
                     )));
                 }
             }
-            Ok(TypeInstance::new(&arg, &target_ti, file))
+            Ok(TypeInstance::new(&arg, target_ti, file))
         }
         _ => {
             let arg_typeinfo = argument_to_typeinfo(&arg, types, class_perms, args, file)?;
@@ -1622,7 +1622,7 @@ fn validate_argument<'a>(
             }
 
             if arg_typeinfo.is_child_or_actual_type(target_argument.param_type, types) {
-                Ok(TypeInstance::new(&arg, &arg_typeinfo, file))
+                Ok(TypeInstance::new(&arg, arg_typeinfo, file))
             } else {
                 Err(HLLErrorItem::Compile(HLLCompileError::new(
                     &format!("Expected type inheriting {}", arg_typeinfo.name.to_string()),

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -109,7 +109,7 @@ impl TypeInfo {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     // Get the type that cil is aware of that this ti falls into

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -263,7 +263,7 @@ fn get_type_annotations(
 
 // strings may be paths or strings
 pub fn type_name_from_string(string: &str) -> String {
-    if string.contains("/") {
+    if string.contains('/') {
         "path".to_string()
     } else {
         "string".to_string()
@@ -458,7 +458,7 @@ impl From<Context<'_>> for sexp::Sexp {
 impl<'a> TryFrom<&'a str> for Context<'a> {
     type Error = ();
     fn try_from(s: &'a str) -> Result<Context<'a>, ()> {
-        let mut split_string = s.split(":");
+        let mut split_string = s.split(':');
         let first_field = split_string.next().ok_or(())?;
         let second_field = split_string.next();
 

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -610,7 +610,7 @@ impl<'a> ClassList<'a> {
         };
 
         if class_struct.perms.contains(&permission.as_ref()) {
-            return Ok(());
+            Ok(())
         } else {
             let other_str = match class.as_ref() {
                 "capability" => Some("capability2"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub fn compile_system_policy(input_files: Vec<&str>) -> Result<String, error::HL
     compile::validate_functions(&mut func_map, &type_map, &classlist, &func_map_copy)?;
 
     for p in &policies {
-        let mut r = match compile::compile_rules_one_file(&p, &classlist, &type_map, &func_map) {
+        let mut r = match compile::compile_rules_one_file(p, &classlist, &type_map, &func_map) {
             Ok(r) => r,
             Err(e) => {
                 errors.append(e);
@@ -377,7 +377,6 @@ mod tests {
                 //assert!(p.contains(
                 //    "(call foo.foo_func"
                 //));
-                ()
             }
             Err(e) => panic!("Makelist compilation failed with {}", e),
         }
@@ -481,7 +480,7 @@ mod tests {
                                     },
                                     ..
                                 })
-                                if msg == "Unexpected character \".\"".to_string()));
+                                if msg == *"Unexpected character \".\""));
                 }
             }
         }
@@ -506,7 +505,7 @@ mod tests {
                                     },
                                     ..
                                 })
-                                if msg == "Unknown character".to_string()));
+                                if msg == *"Unknown character"));
                 }
             }
         }
@@ -531,7 +530,7 @@ mod tests {
                                     },
                                     ..
                                 })
-                                if msg == "Unexpected end of file".to_string()));
+                                if msg == *"Unexpected end of file"));
                 }
             }
         }

--- a/src/obj_class.rs
+++ b/src/obj_class.rs
@@ -4,7 +4,7 @@
 // Object class and permissions declarations live here
 use crate::internal_rep::ClassList;
 
-const COMMON_FILE_SOCK_PERMS: &'static [&'static str] = &[
+const COMMON_FILE_SOCK_PERMS: &[&str] = &[
     "ioctl",
     "read",
     "write",
@@ -18,7 +18,7 @@ const COMMON_FILE_SOCK_PERMS: &'static [&'static str] = &[
     "map",
 ];
 
-const COMMON_FILE_PERMS: &'static [&'static str] = &[
+const COMMON_FILE_PERMS: &[&str] = &[
     "unlink",
     "link",
     "rename",
@@ -35,7 +35,7 @@ const COMMON_FILE_PERMS: &'static [&'static str] = &[
     "watch_reads",
 ];
 
-const COMMON_SOCK_PERMS: &'static [&'static str] = &[
+const COMMON_SOCK_PERMS: &[&str] = &[
     "bind",
     "connect",
     "listen",
@@ -48,7 +48,7 @@ const COMMON_SOCK_PERMS: &'static [&'static str] = &[
     "name_bind",
 ];
 
-const COMMON_IPC_PERMS: &'static [&'static str] = &[
+const COMMON_IPC_PERMS: &[&str] = &[
     "create",
     "destroy",
     "getattr",
@@ -60,7 +60,7 @@ const COMMON_IPC_PERMS: &'static [&'static str] = &[
     "unix_write",
 ];
 
-const COMMON_CAP_PERMS: &'static [&'static str] = &[
+const COMMON_CAP_PERMS: &[&str] = &[
     "chown",
     "dac_override",
     "dac_read_search",
@@ -95,7 +95,7 @@ const COMMON_CAP_PERMS: &'static [&'static str] = &[
     "setfcap",
 ];
 
-const COMMON_CAP2_PERMS: &'static [&'static str] = &[
+const COMMON_CAP2_PERMS: &[&str] = &[
     "mac_override",
     "mac_admin",
     "syslog",


### PR DESCRIPTION
This PR fixes a lot of clippy warnings. Code is now much more idiomatic.

No functional change intended. The code still builds and all tests pass after these changes.