### PR TITLE
Support named args passing with "name=foo" in parser

### DIFF
--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -1654,6 +1654,7 @@ impl<'a> From<&'a Argument> for ArgForValidation<'a> {
     fn from(a: &'a Argument) -> Self {
         match a {
             Argument::Var(s) => ArgForValidation::Var(s),
+            Argument::Named(_n, _a) => todo!(),
             Argument::List(v) => ArgForValidation::List(v.iter().collect()),
             Argument::Quote(s) => ArgForValidation::Quote(s),
         }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -114,6 +114,7 @@ List: Vec<HLLString> = {
 
 Arg: Argument = {
 	Symbol => Argument::Var(<>),
+	<s:Symbol> "=" <a: Arg> => Argument::Named(s, Box::new(a)),
 	List => Argument::List(<>),
 	Quoted_String => Argument::Quote(<>),
 }


### PR DESCRIPTION
Nothing is actually done with these yet.  Future work will need to
override the default ordering assumptions.

In our existing docs, we have used this syntax extensively in
annotations, and (to my knowledge) never in function calls.  For
consistency, we should support both.

The near term need is to support this syntax in annotations.  A
follow-on PR will add actual support here.  Allowing these to work in
the parser allows annotations that have no behavior defined yet, but use
the "name=foo" syntax to at least parse correctly.