### PR TITLE
Continue on TypeInfo declaration errors to display them all

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -93,19 +93,24 @@ pub fn extend_type_map(p: &PolicyFile, type_map: &mut TypeMap) -> Result<(), HLL
     // TODO: This only allows declarations at the top level.
     // Nested declarations are legal, but auto-associate with the parent, so they'll need special
     // handling when association is implemented
+    let mut errors = HLLErrors::new();
     for e in &p.policy.exprs {
         let d = match e {
             Expression::Decl(d) => d,
             _ => continue,
         };
         match d {
-            Declaration::Type(t) => {
-                type_map.insert(t.name.to_string(), TypeInfo::new(*t.clone(), &p.file)?)
-            }
+            Declaration::Type(t) => match TypeInfo::new(*t.clone(), &p.file) {
+                Ok(new_type) => type_map.insert(t.name.to_string(), new_type),
+                Err(e) => {
+                    errors.append(e);
+                    None
+                }
+            },
             Declaration::Func(_) => continue,
         };
     }
-    Ok(())
+    errors.into_result(())
 }
 
 pub fn get_built_in_types_map() -> TypeMap {


### PR DESCRIPTION
I have a unit test for this, but it depends on the @alias annotation to cause the error, and I am still implementing that.  So a unit test will follow in a future PR.