### PR TITLE
Include a backtrace on internal errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = [ "selinux" ]
 lalrpop = "0.19"
 
 [dependencies]
+backtrace = "0.3"
 clap = { version = "3", features = ["derive"] }
 codespan-reporting = "0.11"
 lalrpop-util = "0.19"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -189,7 +189,7 @@ pub fn get_global_bindings(
                             "perm",
                             match a {
                                 ArgForValidation::Var(s) => BoundTypeInfo::Single(s.to_string()),
-                                _ => return Err(InternalError {}.into()),
+                                _ => return Err(InternalError::new().into()),
                             },
                         )
                     } else {
@@ -234,7 +234,7 @@ pub fn build_func_map<'a>(
             Declaration::Type(t) => {
                 let type_being_parsed = match types.get(&t.name.to_string()) {
                     Some(t) => t,
-                    None => return Err(ErrorItem::Internal(InternalError {}).into()),
+                    None => return Err(ErrorItem::Internal(InternalError::new()).into()),
                 };
                 decl_map.extend(build_func_map(
                     &t.expressions,
@@ -360,7 +360,7 @@ fn generate_type_no_parent_errors(missed_types: Vec<&TypeInfo>, types: &TypeMap)
     for t in &missed_types {
         match find_cycles_or_bad_types(t, types, HashSet::new()) {
             Ok(()) => {
-                ret.add_error(InternalError {});
+                ret.add_error(InternalError::new());
                 return ret;
             }
             Err(e) => ret.append(e),
@@ -391,7 +391,7 @@ fn create_synthetic_resource(
             dom_info
                 .declaration_file
                 .as_ref()
-                .ok_or(ErrorItem::Internal(InternalError {}))?,
+                .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?,
             class_string.get_range(),
             "This should be a resource, not a domain.",
         )
@@ -399,7 +399,7 @@ fn create_synthetic_resource(
     }
 
     // Creates a synthetic resource declaration.
-    let mut dup_res_decl = class.decl.as_ref().ok_or(InternalError {})?.clone();
+    let mut dup_res_decl = class.decl.as_ref().ok_or_else(InternalError::new)?.clone();
     let res_name = get_synthetic_resource_name(dom_info, &class.name);
     dup_res_decl.name = res_name.clone();
     // See TypeDecl::new() in parser.lalrpop for resource inheritance.
@@ -424,7 +424,7 @@ fn create_synthetic_resource(
         .filter(|e| dup_res_is_virtual || !e.is_virtual_function())
         .collect();
     if !global_exprs.insert(Expression::Decl(Declaration::Type(Box::new(dup_res_decl)))) {
-        return Err(InternalError {}.into());
+        return Err(InternalError::new().into());
     }
     Ok(res_name)
 }
@@ -486,7 +486,7 @@ fn interpret_associate(
                     vec![Argument::Var("this".into())],
                 ))));
                 if !local_exprs.insert(new_call) {
-                    return Err(ErrorItem::Internal(InternalError {}).into());
+                    return Err(ErrorItem::Internal(InternalError::new()).into());
                 }
             }
         }
@@ -512,7 +512,7 @@ fn interpret_associate(
                 dom_info
                     .declaration_file
                     .as_ref()
-                    .ok_or(ErrorItem::Internal(InternalError {}))?,
+                    .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?,
                 res.get_range(),
                 "didn't find this resource in the policy",
             )),
@@ -667,10 +667,10 @@ pub fn apply_associate_annotations<'a>(
             // TODO: Avoid cloning all expressions.
             let mut new_domain = types
                 .get(&k.to_string())
-                .ok_or(ErrorItem::Internal(InternalError {}))?
+                .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
                 .decl
                 .as_ref()
-                .ok_or(ErrorItem::Internal(InternalError {}))?
+                .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
                 .clone();
             new_domain.expressions = v.into_iter().collect();
             Ok(Expression::Decl(Declaration::Type(Box::new(new_domain))))
@@ -809,7 +809,7 @@ fn do_rules_pass<'a>(
             Expression::Decl(Declaration::Type(t)) => {
                 let type_being_parsed = match types.get(&t.name.to_string()) {
                     Some(t) => t,
-                    None => return Err(ErrorItem::Internal(InternalError {}).into()),
+                    None => return Err(ErrorItem::Internal(InternalError::new()).into()),
                 };
                 match do_rules_pass(
                     &t.expressions,

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -318,7 +318,7 @@ pub fn type_slice_to_variant<'a>(
     let first_type_variant = match type_slice.first() {
         Some(t) => match t.get_built_in_variant(types) {
             Some(v) => v,
-            None => return Err(ErrorItem::Internal(InternalError {}).into()),
+            None => return Err(ErrorItem::Internal(InternalError::new()).into()),
         },
         None => todo!(), // TODO: Return error
     };
@@ -326,7 +326,7 @@ pub fn type_slice_to_variant<'a>(
     for ti in type_slice {
         let ti_variant = match ti.get_built_in_variant(types) {
             Some(v) => v,
-            None => return Err(ErrorItem::Internal(InternalError {}).into()),
+            None => return Err(ErrorItem::Internal(InternalError::new()).into()),
         };
         if ti_variant != first_type_variant {
             todo!() // TODO: Return error
@@ -334,7 +334,7 @@ pub fn type_slice_to_variant<'a>(
     }
     match types.get(first_type_variant) {
         Some(t) => Ok(t),
-        None => Err(ErrorItem::Internal(InternalError {}).into()),
+        None => Err(ErrorItem::Internal(InternalError::new()).into()),
     }
 }
 
@@ -927,7 +927,7 @@ fn call_to_av_rule<'a>(
         constants::DONTAUDIT_FUNCTION_NAME => AvRuleFlavor::Dontaudit,
         constants::AUDITALLOW_FUNCTION_NAME => AvRuleFlavor::Auditallow,
         constants::NEVERALLOW_FUNCTION_NAME => AvRuleFlavor::Neverallow,
-        _ => return Err(ErrorItem::Internal(InternalError {}).into()),
+        _ => return Err(ErrorItem::Internal(InternalError::new()).into()),
     };
 
     let target_args = vec![
@@ -974,23 +974,23 @@ fn call_to_av_rule<'a>(
 
     let source = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_name_or_string()?;
     let target = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_name_or_string()?;
     let class = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_name_or_string()?;
     let perms = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_list()?;
 
     if args_iter.next().is_some() {
-        return Err(ErrorItem::Internal(InternalError {}).into());
+        return Err(ErrorItem::Internal(InternalError::new()).into());
     }
 
     for p in &perms {
@@ -1117,16 +1117,16 @@ fn call_to_fc_rules<'a>(
 
     let regex_string = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_name_or_string()?
         .to_string();
     let file_types = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_list()?;
     let context_str = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .get_name_or_string()?;
     let context = match Context::try_from(context_str.to_string()) {
         Ok(c) => c,
@@ -1224,19 +1224,19 @@ fn call_to_domain_transition<'a>(
 
     let source = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .type_info;
     let executable = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .type_info;
     let target = args_iter
         .next()
-        .ok_or(ErrorItem::Internal(InternalError {}))?
+        .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
         .type_info;
 
     if args_iter.next().is_some() {
-        return Err(ErrorItem::Internal(InternalError {}).into());
+        return Err(ErrorItem::Internal(InternalError::new()).into());
     }
 
     Ok(DomtransRule {
@@ -1504,7 +1504,7 @@ impl TryFrom<&FunctionInfo<'_>> for sexp::Sexp {
             Sexp::List(f.args.iter().map(Sexp::from).collect()),
         ];
         match &f.body {
-            None => return Err(InternalError {}.into()),
+            None => return Err(InternalError::new().into()),
             Some(statements) => {
                 for statement in statements {
                     match statement {
@@ -1772,7 +1772,7 @@ fn convert_class_name_if_this<'a>(
     }
     match parent_type {
         Some(t) => Ok(&t.name),
-        None => Err(InternalError {}.into()),
+        None => Err(InternalError::new().into()),
     }
 }
 
@@ -2074,7 +2074,7 @@ fn validate_argument<'a>(
             }
             let target_ti = match types.get(&target_argument.param_type.name.to_string()) {
                 Some(t) => t,
-                None => return Err(InternalError {}.into()),
+                None => return Err(InternalError::new().into()),
             };
             let arg_typeinfo_vec = argument_to_typeinfo_vec(v, types, class_perms, args, file)?;
 


### PR DESCRIPTION
This makes internal errors debuggable.

This relies on the backtrace crate, as opposed to std::backtrace, which
is only available in nightly.  This causes issues with thiserror, which
if it sees a type named "Backtrace" assumes it must be
std::backtrace::Backtrace, and then fails to compile on stable.  Simply
renaming backtrace::Backtrace seems to work around this.