### PR TITLE
Switch derived resources created via association to use "." in their names

### DIFF
--- a/data/policies/associate.cas
+++ b/data/policies/associate.cas
@@ -25,11 +25,11 @@ virtual resource bin {
 
 @associate([tmp var])
 virtual domain foo {
-	// Creates new resources foo-tmp and foo-var, and implicitly calls
-	// foo-tmp.associated_call_from_tmp(foo) and foo-var.associated_call_from_var(foo)
+	// Creates new resources foo.tmp and foo.var, and implicitly calls
+	// foo.tmp.associated_call_from_tmp(foo) and foo.var.associated_call_from_var(foo)
 	//
-	// foo-tmp inherits tmp
-	// foo-var inherits var
+	// foo.tmp inherits tmp
+	// foo.var inherits var
 
 	tmp.associated_call_from_tmp(this);
 	tmp.not_an_associated_call(this);
@@ -37,28 +37,28 @@ virtual domain foo {
 
 @associate([bin])
 virtual domain bar inherits foo {
-	// Creates new resources bar-tmp, bar-var and bar-bin, and implicitly calls
-	// bar-tmp.associated_call_from_tmp(bar), bar-var.associated_call_from_var(bar) and
-	// bar-bin.associated_call_from_var(bar)
+	// Creates new resources bar.tmp, bar.var and bar.bin, and implicitly calls
+	// bar.tmp.associated_call_from_tmp(bar), bar.var.associated_call_from_var(bar) and
+	// bar.bin.associated_call_from_var(bar)
 	//
-	// bar-bin inherits bin
-	// bar-tmp inherits foo-tmp
-	// bar-var inherits foo-var
+	// bar.bin inherits bin
+	// bar.tmp inherits foo.tmp
+	// bar.var inherits foo.var
 }
 
 domain baz inherits bar {
-	// Creates new resources baz-tmp, baz-var and baz-bin, and implicitly calls
-	// baz-tmp.associated_call_from_tmp(baz), baz-var.associated_call_from_var(baz) and
-	// baz-bin.associated_call_from_var(baz)
+	// Creates new resources baz.tmp, baz.var and baz.bin, and implicitly calls
+	// baz.tmp.associated_call_from_tmp(baz), baz.var.associated_call_from_var(baz) and
+	// baz.bin.associated_call_from_var(baz)
 	//
-	// baz-bin inherits bar-bin
-	// baz-tmp inherits bar-tmp
-	// baz-var inherits bar-var
+	// baz.bin inherits bar.bin
+	// baz.tmp inherits bar.tmp
+	// baz.var inherits bar.var
 }
 
 domain qux {
 	// Calls synthetic functions.
-	foo-tmp.associated_call_from_tmp(this);
-	bar-tmp.associated_call_from_tmp(this);
-	baz-tmp.associated_call_from_tmp(this);
+	foo.tmp.associated_call_from_tmp(this);
+	bar.tmp.associated_call_from_tmp(this);
+	baz.tmp.associated_call_from_tmp(this);
 }

--- a/doc/TE.md
+++ b/doc/TE.md
@@ -170,11 +170,11 @@ Associating a resource with a domain does three things:
 
 1. It causes that resource to be grouped together with the domain when the  
 domain is included in a module or full system policy
-2. It calls the resource's __assoc__() function (if present) with the domain  
+2. It calls any @associated_call member functions in the resource with the domain
 as the first argument.
 3. If the domain is inherited from, a child resource is automatically created  
 and is associated with the child class.  This resource is named  
-`[child name]-[resource name]`.
+`[child name].[resource name]`.
 
 See the specific resource association document for more information.
 

--- a/doc/resource_association.md
+++ b/doc/resource_association.md
@@ -109,17 +109,20 @@ domain some_qemu_domain inherits qemu {}
 ```
 
 In this case, a resource inheriting from `qemu_tmp` is automatically created,
-named `some_qemu_domain-qemu_tmp`, equivalent to the following definition:
+named `some_qemu_domain.qemu_tmp`, equivalent to the following definition:
 
 ```
-resource some_qemu_domain-qemu_tmp inherits qemu_tmp {}
+resource some_qemu_domain.qemu_tmp inherits qemu_tmp {}
 ```
+
+(Although note that explicit declaration of a type containing the character "."
+is disallowed).
 
 The `associate_tmp_files()` call will also automatically be performed as part
 of the inheritance from `qemu`.
 
 Note that a consequence of this is that the "this" keyword in the original
-definition may refer to an automatically created type (some_qemu_domain-qemu-tmp
+definition may refer to an automatically created type (some_qemu_domain.qemu_tmp
 in this example).  This means that there is a distinction between using the type
 name (where it will always refer to the original type) and the keyword "this"
 (which will refer to a specific instantiation such as an inherited or

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -47,6 +47,13 @@ impl CascadeString {
             _ => None,
         }
     }
+
+    // . is used in string for name mangled types in block inheritance
+    // We also use . for name mangled types, but don't implement them as
+    // block inheritance, so we translate to "-" in the resulting CIL
+    pub fn get_cil_name(&self) -> String {
+        self.string.replace('.', "-")
+    }
 }
 
 impl AsRef<str> for CascadeString {
@@ -257,7 +264,7 @@ impl Virtualable for TypeDecl {
 
 pub fn get_cil_name(class_name: Option<&CascadeString>, func_name: &CascadeString) -> String {
     match &class_name {
-        Some(class) => format!("{}-{}", class, func_name),
+        Some(class) => format!("{}-{}", class.get_cil_name(), func_name),
         None => func_name.to_string(),
     }
 }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -1741,7 +1741,7 @@ impl ValidatedCall {
 
         // Each argument must match the type the function signature expects
         let mut args = match &call.class_name {
-            Some(c) => vec![convert_class_name_if_this(c, parent_type)?.to_string()],
+            Some(c) => vec![convert_class_name_if_this(c, parent_type)?.get_cil_name()],
             None => Vec::new(),
         };
 

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -85,7 +85,7 @@ FuncDeclArg: DeclaredArgument = {
 Stmt: Statement = <StmtBody> ";";
 
 StmtBody: Statement = {
-	<c:Symbol> "." <n:Symbol> "(" <a:Comma<Arg>> ")" => Statement::Call(Box::new(FuncCall::new(Some(c), n, a))),
+	<c:TypeName> "." <n:NameDecl> "(" <a:Comma<Arg>> ")" => Statement::Call(Box::new(FuncCall::new(Some(c), n, a))),
 	<n:Symbol> "(" <a:Comma<Arg>> ")" => Statement::Call(Box::new(FuncCall::new(None, n, a))),
 	"let" <n:Symbol> "=" <a:Arg> => Statement::LetBinding(Box::new(LetBinding::new(n, a))),
 }
@@ -93,6 +93,11 @@ StmtBody: Statement = {
 Ann: Annotation = {
 	"@" <s:NameDecl> "(" <a:Comma<Arg>> ")" => Annotation::new(s).set_arguments(a),
 	"@" <s:NameDecl> => Annotation::new(s),
+}
+
+TypeName: CascadeString = {
+	Symbol,
+	<start: @L> <l: TypeName> "." <r: Symbol> <end: @R> => CascadeString::new([l.as_ref(), ".", r.as_ref()].concat(), start..end)
 }
 
 pub NameDecl: CascadeString = {
@@ -105,8 +110,6 @@ pub NameDecl: CascadeString = {
 }
 
 Symbol: CascadeString = {
-	// Less constrained than NameDecl and accepts '-', which enables to use synthetic resources.
-	<start: @L> <s: r"[a-zA-Z]+-[0-9a-zA-Z_-]*[0-9a-zA-Z]"> <end: @R>  => CascadeString::new(s.to_string(), start..end),
 	NameDecl,
 	BuiltInType
 }


### PR DESCRIPTION
instead of "-".

This is more consistent with expectations and typical usage.