### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -239,7 +239,7 @@ pub fn get_global_bindings(
                 }
             };
             if variant == "perm" {
-                classlist.insert_perm_set(&l.name.to_string(), bound_type.get_contents_as_vec())
+                classlist.insert_perm_set(l.name.as_ref(), bound_type.get_contents_as_vec())
             } else {
                 let new_type = TypeInfo::new_bound_type(
                     l.name.clone(),
@@ -270,7 +270,7 @@ pub fn build_func_map<'a>(
         };
         match d {
             Declaration::Type(t) => {
-                let type_being_parsed = match types.get(&t.name.to_string()) {
+                let type_being_parsed = match types.get(t.name.as_ref()) {
                     Some(t) => t,
                     None => return Err(ErrorItem::Internal(InternalError::new()).into()),
                 };
@@ -875,7 +875,7 @@ pub fn apply_associate_annotations<'a>(
         .map(|(k, v)| {
             // TODO: Avoid cloning all expressions.
             let mut new_domain = types
-                .get(&k.to_string())
+                .get(k.as_ref())
                 .ok_or_else(|| ErrorItem::Internal(InternalError::new()))?
                 .decl
                 .as_ref()
@@ -1018,7 +1018,7 @@ fn do_rules_pass<'a>(
                 }
             }
             Expression::Decl(Declaration::Type(t)) => {
-                let type_being_parsed = match types.get(&t.name.to_string()) {
+                let type_being_parsed = match types.get(t.name.as_ref()) {
                     Some(t) => t,
                     None => return Err(ErrorItem::Internal(InternalError::new()).into()),
                 };

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -1256,10 +1256,10 @@ impl From<&DomtransRule<'_>> for sexp::Sexp {
     fn from(d: &DomtransRule) -> Self {
         list(&[
             atom_s("typetransition"),
-            atom_s(&d.source.name.to_string()),
-            atom_s(&d.executable.name.to_string()),
+            atom_s(d.source.name.as_ref()),
+            atom_s(d.executable.name.as_ref()),
             atom_s("process"),
-            atom_s(&d.target.name.to_string()),
+            atom_s(d.target.name.as_ref()),
         ])
     }
 }
@@ -1611,9 +1611,9 @@ impl TryFrom<&FunctionInfo<'_>> for sexp::Sexp {
                 for statement in statements {
                     match statement {
                         ValidatedStatement::Call(c) => macro_cil.push(Sexp::from(&**c)),
-                        ValidatedStatement::AvRule(a) => macro_cil.push(Sexp::from(&*a)),
-                        ValidatedStatement::FcRule(f) => macro_cil.push(Sexp::from(&*f)),
-                        ValidatedStatement::DomtransRule(d) => macro_cil.push(Sexp::from(&*d)),
+                        ValidatedStatement::AvRule(a) => macro_cil.push(Sexp::from(a)),
+                        ValidatedStatement::FcRule(f) => macro_cil.push(Sexp::from(f)),
+                        ValidatedStatement::DomtransRule(d) => macro_cil.push(Sexp::from(d)),
                     }
                 }
             }
@@ -1636,7 +1636,7 @@ impl<'a> FunctionArgument<'a> {
         types: &'a TypeMap,
         file: Option<&SimpleFile<String, String>>,
     ) -> Result<Self, ErrorItem> {
-        let param_type = match types.get(&declared_arg.param_type.to_string()) {
+        let param_type = match types.get(declared_arg.param_type.as_ref()) {
             Some(ti) => ti,
             None => {
                 return Err(ErrorItem::make_compile_or_internal_error(
@@ -2276,7 +2276,7 @@ fn validate_argument<'a>(
                     "This function requires a non-list value here",
                 )));
             }
-            let target_ti = match types.get(&target_argument.param_type.name.to_string()) {
+            let target_ti = match types.get(target_argument.param_type.name.as_ref()) {
                 Some(t) => t,
                 None => return Err(InternalError::new().into()),
             };


### PR DESCRIPTION
Updating to Clippy version 0.1.62 gives new borrow_deref_ref and
unnecessary_to_owned warnings that weren't seen on previous clippy
versions.