### PR TITLE
Silently ignore cleanup failures when updating golden results

### DIFF
--- a/tools/update-expected-cil.sh
+++ b/tools/update-expected-cil.sh
@@ -14,7 +14,7 @@ for f in data/policies/*.cas; do
 		mv out.cil "data/expected_cil/$(basename -- "${f%%.cas}").cil"
 		printf '\r[+]\n'
 	else
-		rm out.cil
+		rm out.cil 2>/dev/null || true
 		printf '\r[-]\n'
 	fi
 done


### PR DESCRIPTION
Prior to commit 60668b87943cd8e4102a53650f561d1e6c7bc0d4, casc would
create a cil output file unconditionally, resulting in an empty file in
the event of a compilation failure.  That commit moved the logic to only
create an output file upon successful compilation.

The new behavior is obviously better, but tools/update-expected-cil.sh
had an implicit bad assumption that out.cil would always exist after a
compilation attempt, and attempt to remove it.  Since the script sets
-e, a failure to cleanup fails the script.

Fix the script to redirect cleanup errors to /dev/null and always return
true on cleanup.