### PR TITLE
Fix handling of the "any" keyword in file contexts

### DIFF
--- a/data/expected_cil/filecon.cil
+++ b/data/expected_cil/filecon.cil
@@ -122,6 +122,7 @@
 (allow domain foo (file (read)))
 (filecon "/bin" file (system_u object_r foo ((s0) (s0))))
 (filecon "/bin" dir (system_u object_r foo ((s0) (s0))))
+(filecon "/etc" any (system_u object_r foo ((s0) (s0))))
 (sid kernel)
 (sidcontext kernel (system_u system_r kernel_sid ((s0) (s0))))
 (sid security)

--- a/data/policies/filecon.cas
+++ b/data/policies/filecon.cas
@@ -1,5 +1,6 @@
 resource foo {
 	file_context("/bin", [file dir], foo);
+	file_context("/etc", [any], this);
 	// Policies must include at least one av rule
 	allow(domain, foo, file, [read]);
 }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -965,6 +965,10 @@ impl<'a> ClassList<'a> {
     }
 
     pub fn is_class(&self, class: &str) -> bool {
+        // "any" is a special keyword to represent any class
+        if class == "any" {
+            return true;
+        }
         self.classes.get(class).is_some()
     }
 
@@ -1141,7 +1145,7 @@ impl FromStr for FileType {
             "block_dev" => Ok(FileType::BlockDev),
             "socket" => Ok(FileType::Socket),
             "pipe" => Ok(FileType::Pipe),
-            "" => Ok(FileType::Any),
+            "any" => Ok(FileType::Any),
             _ => Err(()),
         }
     }
@@ -2612,7 +2616,7 @@ mod tests {
     fn file_type_from_string_test() {
         let file_type = "file".parse::<FileType>().unwrap();
         assert!(matches!(file_type, FileType::File));
-        let file_type = "".parse::<FileType>().unwrap();
+        let file_type = "any".parse::<FileType>().unwrap();
         assert!(matches!(file_type, FileType::Any));
 
         assert!("bad_type".parse::<FileType>().is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,7 +526,11 @@ mod tests {
     fn filecon_test() {
         valid_policy_test(
             "filecon.cas",
-            &["(filecon \"/bin\" file (", "(filecon \"/bin\" dir ("],
+            &[
+                "(filecon \"/bin\" file (",
+                "(filecon \"/bin\" dir (",
+                "(filecon \"/etc\" any (",
+            ],
             &[],
         );
     }


### PR DESCRIPTION
The "any" keyword makes a file context match any object class. Previously, this was supposed to be indicated by the empty string, but that didn't actually make any sense, because it's in an unquoted context and whitespace is skipped by the lexer, so there's no actual way to indicate an empty string file context.

Fix this by using the keyword "any" (the new Cascade keyword now matches the CIL keyword with the same purpose).

Also, expand the file_context test to test the any keyword