### PR TITLE
Test determinism in multifile test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,14 +676,19 @@ mod tests {
         let mut policy_files_reversed = policy_files.clone();
         policy_files_reversed.reverse();
 
+        let mut policies = Vec::new();
+
         for files in [policy_files, policy_files_reversed] {
             match compile_combined(files) {
                 Ok(p) => {
                     assert!(p.contains("(call foo-read"));
+                    policies.push(p);
                 }
                 Err(e) => panic!("Multi file compilation failed with {}", e),
             }
         }
+
+        assert_eq!(policies[0], policies[1]);
     }
 
     #[test]


### PR DESCRIPTION
The test varies the order of files to ensure that both orders compile. Also compare the final policies.  They should agree entirely regardless of input file order.