### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -951,12 +951,10 @@ fn create_synthetic_resource(
         .iter_mut()
         .for_each(|e| e.set_class_name_if_decl(res_name.clone()));
 
-    dup_res_decl.expressions = dup_res_decl
+    dup_res_decl
         .expressions
-        .into_iter()
         // If dup_res_decl is concrete, do not inherit virtual functions
-        .filter(|e| dup_res_is_virtual || !e.is_virtual_function())
-        .collect();
+        .retain(|e| dup_res_is_virtual || !e.is_virtual_function());
     if !global_exprs.insert(Expression::Decl(Declaration::Type(Box::new(dup_res_decl)))) {
         return Err(InternalError::new().into());
     }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -371,14 +371,10 @@ impl TypeInfo {
     // It's possible to inherit from multiple built-ins, so order matters here.  We return the
     // first type in order of preference.
     pub fn get_built_in_variant(&self, types: &TypeMap) -> Option<&str> {
-        for t in constants::BUILT_IN_TYPES {
-            if self.is_type_by_name(types, t) {
-                return Some(t);
-            }
-        }
-
-        // I don't think this should be logically possible
-        None
+        constants::BUILT_IN_TYPES
+            .iter()
+            .find(|t| self.is_type_by_name(types, t))
+            .copied()
     }
 
     pub fn defines_function(&self, virtual_function_name: &str, functions: &FunctionMap) -> bool {


### PR DESCRIPTION
Introduced by latest clippy version.

https://rust-lang.github.io/rust-clippy/master/index.html#manual_retain

Manual find
(https://rust-lang.github.io/rust-clippy/master/index.html#manual_find) provides a broken suggested fix and seems to require an extra unneeded copy to work around the fact that find adds a layer of indirection vs the implemented approach.