### PR TITLE
Detect whether we are writing to a terminal and conditionally enable color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ clap = { version = "3", features = ["derive"] }
 clap_mangen = "0.1"
 
 [dependencies]
+atty = "0.2"
 backtrace = "0.3"
 clap = { version = "3", features = ["derive"] }
 codespan-reporting = "0.11"
 lalrpop-util = "0.19"
 regex = "1"
 sexp = "1.1"
+termcolor = "1.1"
 thiserror = "1.0"
 walkdir = "2"

--- a/src/bin/casc/args.rs
+++ b/src/bin/casc/args.rs
@@ -20,8 +20,11 @@ pub struct Args {
     #[clap(default_value = "out.cil", short, value_parser = clap::builder::ValueParser::new(parse_out_filename))]
     pub out_filename: String,
     /// Build the systems from the SYSTEM_NAMES list. "-s all" to build all defined systems.
-    #[clap(short, multiple_values = true, conflicts_with = "out-filename")]
+    #[clap(short, conflicts_with = "out-filename")]
     pub system_names: Vec<String>,
+    ///colorize the output.  WHEN can be 'always', 'auto' (default), or 'never'
+    #[clap(long, value_enum, id = "WHEN")]
+    pub color: Option<ColorArg>,
 }
 
 fn parse_out_filename(filename: &str) -> Result<String, String> {
@@ -29,4 +32,11 @@ fn parse_out_filename(filename: &str) -> Result<String, String> {
         return Ok(filename.to_string());
     }
     Err(String::from("The value does not end in \".cil\""))
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum ColorArg {
+    Always,
+    Auto,
+    Never,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,12 +10,12 @@ use backtrace::Backtrace as BacktraceCrate;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::{SimpleFile, SimpleFiles};
 use codespan_reporting::term;
-use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use lalrpop_util::lexer::Token;
 use lalrpop_util::ParseError as LalrpopParseError;
 use std::fmt;
 use std::io;
 use std::ops::Range;
+use termcolor::{ColorChoice, StandardStream};
 use thiserror::Error;
 
 #[derive(Error, Clone, Debug)]
@@ -65,8 +65,8 @@ impl CompileError {
             files,
         }
     }
-    pub fn print_diagnostic(&self) {
-        let writer = StandardStream::stderr(ColorChoice::Auto);
+    pub fn print_diagnostic(&self, color: ColorChoice) {
+        let writer = StandardStream::stderr(color);
         let config = term::Config::default();
         // Ignores print errors.
         let _ = term::emit(
@@ -186,8 +186,8 @@ impl ParseError {
         }
     }
 
-    pub fn print_diagnostic(&self) {
-        let writer = StandardStream::stderr(ColorChoice::Auto);
+    pub fn print_diagnostic(&self, color: ColorChoice) {
+        let writer = StandardStream::stderr(color);
         let config = term::Config::default();
         // Ignores print errors.
         let _ = term::emit(


### PR DESCRIPTION
Detect whether we are writing to a terminal and conditionally enable color on error output

I had assumed termcolor did this for us, but according to their documentation, they do not, and recommend using the atty crate for this purpose: https://docs.rs/termcolor/latest/termcolor/#detecting-presence-of-a-terminal

The approach in this commit lets casc determine whether or not to use color, and then error.rs translates that boolean decision into the appropriate termcolor commands.  Casc makes its decision in turn based on atty detecting a terminal.  This architecture allows for future binaries to make different decisions if needed (eg a --nocolor flag).

Reported-by: Matthew Sheets <masheets@linux.microsoft.com>