### PR TITLE
Update to clap v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = [ "selinux" ]
 
 [build-dependencies]
 lalrpop = "0.19"
-clap = { version = "3", features = ["derive"] }
-clap_mangen = "0.1"
+clap = { version = "4", features = ["derive"] }
+clap_mangen = "0.2"
 
 [dependencies]
 atty = "0.2"
 backtrace = "0.3"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 codespan-reporting = "0.11"
 lalrpop-util = "0.19"
 regex = "1"

--- a/src/bin/casc/args.rs
+++ b/src/bin/casc/args.rs
@@ -20,7 +20,7 @@ pub struct Args {
     #[clap(default_value = "out.cil", short, value_parser = clap::builder::ValueParser::new(parse_out_filename))]
     pub out_filename: String,
     /// Build the systems from the SYSTEM_NAMES list. "-s all" to build all defined systems.
-    #[clap(short, conflicts_with = "out-filename")]
+    #[clap(short, conflicts_with = "out_filename")]
     pub system_names: Vec<String>,
     ///colorize the output.  WHEN can be 'always', 'auto' (default), or 'never'
     #[clap(long, value_enum, id = "WHEN")]

--- a/src/bin/casc/args.rs
+++ b/src/bin/casc/args.rs
@@ -40,3 +40,14 @@ pub enum ColorArg {
     Auto,
     Never,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn test_cli() {
+        Args::command().debug_assert();
+    }
+}


### PR DESCRIPTION
I was expecting this to be much more difficult than it turned out to be.  Back when 3.2.2 first was released, we hit a bunch of warnings, as described in this clap issue: https://github.com/clap-rs/clap/issues/3822.  Clap moved those warnings behind the "deprecated" feature flag in v3.2.3.  I was expecting to need to address the warnings I saw when updating to clap 3.2.2 before updating to v4, however those warnings seem to no longer occur.  Perhaps they were accidentally addressed as we generally updated our CLI based on online docs?  Or perhaps something changed on the clap end?

Regardless, updating clap and clap_mangen in concert, and fixing the one `_`/`-` confusion in the commit seems to have everything working functionally as far as I can tell.

As a future note, the clap migrating instructions suggest using the "trycmd" crate to do cli testing.  That could be a good future enhancement, but is more than I wanted to get into in this PR.  Currently our testing focused on the cascade library calls, and casc automated testing is extremely minimal (first casc specific test is in this PR).