### PR TITLE
Drop extra parentheses around "all" in permission set.

### DIFF
--- a/data/expected_cil/permissions.cil
+++ b/data/expected_cil/permissions.cil
@@ -124,7 +124,7 @@
 (type unlabeled_sid)
 (roletype object_r unlabeled_sid)
 (typeattributeset resource (unlabeled_sid))
-(allow foo bar (file ((all))))
+(allow foo bar (file (all)))
 (allow foo foo (capability (fowner)))
 (allow foo foo (capability2 (mac_override)))
 (allow foo foo (capability2 (wake_alarm)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,7 +816,7 @@ mod tests {
                 "(allow foo foo (capability (fowner)))",
                 "(allow foo foo (capability2 (mac_override)))",
                 "(allow foo foo (capability2 (wake_alarm)))",
-                "(allow foo bar (file ((all))))",
+                "(allow foo bar (file (all)))",
             ],
             &["(capabilty (mac_override", "(capability (wake_alarm"],
         );

--- a/src/obj_class.rs
+++ b/src/obj_class.rs
@@ -597,7 +597,7 @@ pub fn make_classlist() -> ClassList<'static> {
 
 pub fn perm_list_to_sexp(perms: &[CascadeString]) -> Vec<sexp::Sexp> {
     if perms.iter().any(|p| p == "*") {
-        vec![Sexp::Atom(Atom::S("(all)".to_string()))]
+        vec![Sexp::Atom(Atom::S("all".to_string()))]
     } else {
         perms
             .iter()


### PR DESCRIPTION
The Vec being returned is turned into a list, so wrapping "all" in parentheses results in a list inside a list.  That behavior is supported by CIL, so it compiles, but the extra parentheses are unneeded.

Reported-by: Dominick Grift <dominick.grift@defensec.nl>