### PR TITLE
Clean up error handling to avoid error messages without code points

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -765,7 +765,7 @@ fn check_required_config<'a>(
                     config_name
                 ),
                 Some(file),
-                None,
+                machine.name.get_range(),
                 &format!(
                     "Add a {} configuration to machine {}",
                     config_name, machine.name

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -375,7 +375,7 @@ pub fn validate_functions<'a>(
                     errors.append(CascadeErrors::from(ErrorItem::make_compile_or_internal_error(
                                 &format!("{} does not define a function named {}", setype.name, required_function_name),
                                 setype.declaration_file.as_ref(),
-                                parent.get_range(),
+                                setype.name.get_range(),
                                 // TODO: fix message
                                 &format!("All types inheriting {} are required to implement {} because it is marked as virtual", parent, required_function_name))))
                 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -372,11 +372,13 @@ pub fn validate_functions<'a>(
                 .unwrap_or(&BTreeSet::new())
             {
                 if !setype.defines_function(required_function_name, &functions) {
+                    // TODO: this can return an internal error if a synthetic type doesn't declare
+                    // a required function.  Instead, we should return a CompileError that provides
+                    // a suggestion to provide an implementation somewhere
                     errors.append(CascadeErrors::from(ErrorItem::make_compile_or_internal_error(
                                 &format!("{} does not define a function named {}", setype.name, required_function_name),
                                 setype.declaration_file.as_ref(),
                                 setype.name.get_range(),
-                                // TODO: fix message
                                 &format!("All types inheriting {} are required to implement {} because it is marked as virtual", parent, required_function_name))))
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -982,7 +982,13 @@ mod tests {
 
     #[test]
     fn virtual_function_associate_error() {
-        error_policy_test!("virtual_function_association.cas", 1, ErrorItem::Compile(_));
+        // TODO: This should be a compile error.  See comment in validate_functions()
+        error_policy_test!(
+            "virtual_function_association.cas",
+            1,
+            ErrorItem::Internal(_)
+        );
+        //error_policy_test!("virtual_function_association.cas", 1, ErrorItem::Compile(_));
     }
 
     #[test]


### PR DESCRIPTION
Previously, if an error was reported based on internally generated code, an error would be reported without referencing a code point, which isn't actionable.  This series changes that situation to an internal error, and cleans up several internal error situations so that they accurately point to a code point.

In general, we should not be reporting errors directly on internally generated code.  Our error messages should point directly at the source the user wrote that triggered the compile error.