### PR TITLE
Fix bug where context lookups discarded the range

### DIFF
--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -2750,7 +2750,7 @@ impl<'a> TypeInstance<'a> {
                     }
                 } else {
                     context
-                        .get_name_or_string(s.as_ref())
+                        .get_name_or_string(s)
                         .ok_or_else(|| InternalError::new().into())
                 }
             }


### PR DESCRIPTION
Previously context lookups were done on string slices instead of CascadeStrings, meaning that returning the looked up value required constructing a new CascadeString with None range.  Instead, have them take CascadeStrings, so if the lookup fails, we can just return the full CascadeString with its range.

closes #92