### PR TITLE
Run PR failing style checks only on a known good toolchain version

### DIFF
--- a/.github/workflows/clippy.sh
+++ b/.github/workflows/clippy.sh
@@ -2,6 +2,8 @@
 
 set -e -u -o pipefail
 
-rustup run stable cargo clippy -- -A clippy::new_without_default --deny warnings
+VERSION=${1:-stable}
 
-rustup run stable cargo clippy --tests -- -A clippy::new_without_default -A clippy::expect_fun_call
+rustup run ${VERSION} cargo clippy -- -A clippy::new_without_default --deny warnings
+
+rustup run ${VERSION} cargo clippy --tests -- -A clippy::new_without_default -A clippy::expect_fun_call

--- a/.github/workflows/doc.sh
+++ b/.github/workflows/doc.sh
@@ -2,4 +2,6 @@
 
 set -e -u -o pipefail
 
-rustup run stable cargo doc --no-deps
+VERSION=${1:-stable}
+
+rustup run ${VERSION} cargo doc --no-deps

--- a/.github/workflows/format.sh
+++ b/.github/workflows/format.sh
@@ -2,4 +2,6 @@
 
 set -e -u -o pipefail
 
-rustup run stable cargo fmt --all -- --check
+VERSION=${1:-stable}
+
+rustup run ${VERSION} cargo fmt --all -- --check

--- a/.github/workflows/restore-checks.sh
+++ b/.github/workflows/restore-checks.sh
@@ -2,10 +2,14 @@
 
 set -e -u -o pipefail
 
+VERSION=${1:-stable}
+
 # https://nickb.dev/blog/azure-pipelines-for-rust-projects
 curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y
 export PATH="${PATH}:${HOME}/.cargo/bin"
 echo "##vso[task.setvariable variable=PATH;]${PATH}"
 
 rustup toolchain install nightly
+
+rustup toolchain install ${VERSION}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,20 @@ jobs:
     - name: Check format
       run: .github/workflows/format.sh ${{ matrix.rust-toolchain }}
     - name: Check clippy
+      id: clippy
       run: .github/workflows/clippy.sh ${{ matrix.rust-toolchain }}
       continue-on-error: ${{ matrix.experimental }}
+    - name: Notify clippy failure
+      if: ${{ (steps.clippy.outcome != steps.clippy.conclusion) && matrix.experimental }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Stable clippy has failed for this run. A maintainer should check the logs. If known good clippy passed, this is non-fatal to the PR.'
+          })
     - name: Check docs
       run: .github/workflows/doc.sh ${{ matrix.rust-toolchain }}
     - name: Nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,16 +21,28 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        # We lock our failing tests on a known good version and
+        # informationally check the latest as well.  We should
+        # regularly update the known good once we know that tests
+        # pass on it
+        rust-toolchain: [ 1.65 ]
+        experimental: [false]
+        include:
+          - rust-toolchain: stable
+            experimental: true
     steps:
     - uses: actions/checkout@v3
     - name: Setup
-      run: .github/workflows/restore-nightly.sh
+      run: .github/workflows/restore-checks.sh ${{ matrix.rust-toolchain }}
     - name: Check format
-      run: .github/workflows/format.sh
+      run: .github/workflows/format.sh ${{ matrix.rust-toolchain }}
     - name: Check clippy
-      run: .github/workflows/clippy.sh
+      run: .github/workflows/clippy.sh ${{ matrix.rust-toolchain }}
+      continue-on-error: ${{ matrix.experimental }}
     - name: Check docs
-      run: .github/workflows/doc.sh
+      run: .github/workflows/doc.sh ${{ matrix.rust-toolchain }}
     - name: Nightly
       run: .github/workflows/nightly.sh
   test:


### PR DESCRIPTION
Clippy regularly updates with new checks.  When this happens, we update our repo to account for this (either fixing the code, or disabling the checks).  However, this often hits a new PR that happens to be the first PR to run against the new check.  That PR doesn't necessarily introduce an issue, but fails anyways.

Split the style checks to run against an older known good version of the toolchain, which can fail PRs, and also informationally run against the latest toolchain.  This way, PRs won't block on new clippy checks, but we'll still be notified of the need to fix them.

Once we fix the latest clippy checks, we can update the known good version to the new clippy version and continue checking against that version.

Clippy is the specific example here, but this updates the toolchain for the full checks step (except building nightly) so that we're running against a stable known good for all style checking.