### PR TITLE
Allow context nesting

### DIFF
--- a/data/error_policies/let_invalid_type.cas
+++ b/data/error_policies/let_invalid_type.cas
@@ -1,0 +1,7 @@
+let bar = baz;
+
+resource foo {}
+
+domain qux {
+	allow(this, foo, file, read);
+}

--- a/data/expected_cil/let.cil
+++ b/data/expected_cil/let.cil
@@ -145,6 +145,7 @@
 (allow foo bar (file (entrypoint setattr)))
 (allow foo bar (file (read)))
 (allow foo bar (file (read open getattr)))
+(allow foo bar (file (write)))
 (auditallow foo bar (file (read open getattr)))
 (sid kernel)
 (sidcontext kernel (system_u system_r kernel_sid ((s0) (s0))))

--- a/data/policies/let.cas
+++ b/data/policies/let.cas
@@ -8,8 +8,7 @@ let rw_file_perms = [ read_file_perms write ];
 
 resource bar {}
 
-// TODO: re-add once global binding is using Contexts
-//let baz = bar;
+let baz = bar;
 
 domain foo {
 
@@ -21,5 +20,5 @@ domain foo {
 	allow(foo, bar, file, binding_with_annotation);
 	allow(this, bar, file, internal_binding);
 	allow(this, bar, file, nested_binding);
-	//allow(foo, baz, file, write);
+	allow(foo, baz, file, write);
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -909,12 +909,12 @@ fn check_required_config(
 }
 
 // Get the types, functions, and policy rules for the machine.
-pub fn get_reduced_infos<'a>(
-    policies: &'a [PolicyFile],
-    classlist: &'a ClassList,
-    machine: &'a ValidatedMachine,
-    type_map: &'a TypeMap,
-    module_map: &'a ModuleMap,
+pub fn get_reduced_infos(
+    policies: &[PolicyFile],
+    classlist: &ClassList,
+    machine: &ValidatedMachine,
+    type_map: &TypeMap,
+    module_map: &ModuleMap,
 ) -> Result<Vec<sexp::Sexp>, CascadeErrors> {
     let ret = CascadeErrors::new();
     let mut new_type_map = get_built_in_types_map()?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -34,7 +34,7 @@ pub fn argument_to_typeinfo<'a>(
     file: Option<&SimpleFile<String, String>>,
 ) -> Result<&'a TypeInfo, ErrorItem> {
     let t: Option<&TypeInfo> = match a {
-        ArgForValidation::Var(s) => match context.symbol_in_context(s.as_ref()) {
+        ArgForValidation::Var(s) => match context.symbol_in_context(s.as_ref(), types) {
             Some(res) => Some(res),
             // In annotations, we want to treat arguments as strings and the annotation is
             // responsible for understanding what they refer to.  This allows annotations to work
@@ -1623,7 +1623,7 @@ impl<'a> FunctionInfo<'a> {
     ) -> Result<(), CascadeErrors> {
         let mut new_body = BTreeSet::new();
         let mut errors = CascadeErrors::new();
-        let local_context = BlockContext::new_from_args(&self.args, types, self.class);
+        let local_context = BlockContext::new_from_args(&self.args, self.class);
 
         for statement in self.original_body {
             // TODO: This needs to become global in a bit
@@ -2283,7 +2283,7 @@ impl<'a> ArgForValidation<'a> {
         let check_validity = |s: &CascadeString| {
             if types.get(s.as_ref()).is_none()
                 && !context
-                    .symbol_in_context(s.as_ref())
+                    .symbol_in_context(s.as_ref(), types)
                     .map(|ti| ti.is_setype(types))
                     .unwrap_or(false)
             {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -255,10 +255,10 @@ fn call_to_av_rule<'a>(
     }
 
     for p in &perms {
-        class_perms.verify_permission(&class, p, file)?;
+        class_perms.verify_permission(&class, p, context, file)?;
     }
 
-    let perms = class_perms.expand_perm_list(perms.iter().collect());
+    let perms = ClassList::expand_perm_list(perms.iter().collect(), context);
 
     let av_rules = if is_collapsed_class(class.as_ref()) {
         let mut split_perms = (Vec::new(), Vec::new());
@@ -1619,11 +1619,12 @@ impl<'a> FunctionInfo<'a> {
         functions: &'a FunctionMap<'a>,
         types: &'a TypeMap,
         class_perms: &'a ClassList,
+        context: &BlockContext<'_>,
         file: &'a SimpleFile<String, String>,
     ) -> Result<(), CascadeErrors> {
         let mut new_body = BTreeSet::new();
         let mut errors = CascadeErrors::new();
-        let local_context = BlockContext::new_from_args(&self.args, self.class);
+        let local_context = BlockContext::new_from_args(&self.args, self.class, context);
 
         for statement in self.original_body {
             // TODO: This needs to become global in a bit

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -472,7 +472,7 @@ pub fn validate_derive_args<'a>(
     // TODO: We might actually be in a context here, once nested type declarations are supported
     // TODO: Even if we're not doing a nested type annotation, we should be in the global context I
     // think, at least as a parent
-    let local_context = BlockContext::new(BlockType::Annotation, types, None, None);
+    let local_context = BlockContext::new(BlockType::Annotation, None, None);
     let file = target_type.declaration_file.as_ref();
     let target_args = vec![
         FunctionArgument::new(
@@ -1130,8 +1130,7 @@ mod tests {
     fn typeinstance_test() {
         let type_info = TypeInfo::make_built_in("foo".to_string(), false);
         let file = SimpleFile::new("some_file.txt".to_string(), "contents".to_string());
-        let tm = TypeMap::new();
-        let context = BlockContext::new(BlockType::Global, &tm, None, None);
+        let context = BlockContext::new(BlockType::Global, None, None);
         let type_instance = TypeInstance {
             instance_value: TypeValue::SEType(Some(2..4)),
             type_info: Cow::Borrowed(&type_info),

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -470,7 +470,9 @@ pub fn validate_derive_args<'a>(
     class_perms: &ClassList,
 ) -> Result<(BTreeSet<&'a CascadeString>, Vec<CascadeString>), CascadeErrors> {
     // TODO: We might actually be in a context here, once nested type declarations are supported
-    let local_context = BlockContext::new(BlockType::Annotation, types, None);
+    // TODO: Even if we're not doing a nested type annotation, we should be in the global context I
+    // think, at least as a parent
+    let local_context = BlockContext::new(BlockType::Annotation, types, None, None);
     let file = target_type.declaration_file.as_ref();
     let target_args = vec![
         FunctionArgument::new(
@@ -1129,7 +1131,7 @@ mod tests {
         let type_info = TypeInfo::make_built_in("foo".to_string(), false);
         let file = SimpleFile::new("some_file.txt".to_string(), "contents".to_string());
         let tm = TypeMap::new();
-        let context = BlockContext::new(BlockType::Global, &tm, None);
+        let context = BlockContext::new(BlockType::Global, &tm, None, None);
         let type_instance = TypeInstance {
             instance_value: TypeValue::SEType(Some(2..4)),
             type_info: Cow::Borrowed(&type_info),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1299,6 +1299,11 @@ mod tests {
     }
 
     #[test]
+    fn let_invalid_type() {
+        error_policy_test!("let_invalid_type.cas", 1, ErrorItem::Compile(_));
+    }
+
+    #[test]
     fn valid_resourcetrans() {
         valid_policy_test(
             "resource_trans.cas",


### PR DESCRIPTION
The symbol table should nest within blocks and do shadowed lookups.  This enables the removal of the special handling for global bindings, which was pretty broken.