### PR TITLE
ci: Bump known good clippy to 1.67

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
         # informationally check the latest as well.  We should
         # regularly update the known good once we know that tests
         # pass on it
-        rust-toolchain: [ 1.66, stable, nightly ]
+        rust-toolchain: [ 1.67, stable, nightly ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup
@@ -37,9 +37,9 @@ jobs:
     - name: Check clippy
       id: clippy
       run: .github/workflows/clippy.sh ${{ matrix.rust-toolchain }}
-      continue-on-error: ${{ matrix.rust-toolchain != '1.66' }}
+      continue-on-error: ${{ matrix.rust-toolchain != '1.67' }}
     - name: Notify clippy failure
-      if: ${{ (steps.clippy.outcome != steps.clippy.conclusion) && (matrix.rust-toolchain != '1.66') }}
+      if: ${{ (steps.clippy.outcome != steps.clippy.conclusion) && (matrix.rust-toolchain != '1.67') }}
       uses: actions/github-script@v6
       with:
         script: |


### PR DESCRIPTION
Rust has released the new 1.67 toolchain and it introduces no new clippy failures on our main branch