### PR TITLE
Remove already addressed TODO in trait_test()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,8 +839,6 @@ mod tests {
 
     #[test]
     fn trait_test() {
-        // TODO: The "this" keyword is broken without other PRs.  Flesh out expected results once
-        // that and derive have merged
         valid_policy_test("trait.cas", &["(macro baz-write ((type this) (type source)) (allow source this (file (write))))",
         "(macro foo-write ((type this) (type source)) (allow source this (dir (write))))",
         "(macro my_trait-write ((type this) (type source)) (allow source this (file (write))))",],


### PR DESCRIPTION
The TODO item was addressed in 69c1586e7f1c9eb01da773e4cc4ce3ba5eddcbba, but the TODO comment wasn't removed