### PR TITLE
Bad Perms report for correct object class

### DIFF
--- a/data/error_policies/bad_allow.cas
+++ b/data/error_policies/bad_allow.cas
@@ -4,4 +4,6 @@ domain foo {
 	allow(this);
 	allow(this, bar, [file dir], [read write]);
 	allow(this, bar, file, bad_perm);
+	allow(this, this<resource>, capability, [ read write ]);
+	allow(this, this<resource>, capability2, [ read ]);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -139,15 +139,17 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn get_list(&self, arg: &str) -> Vec<CascadeString> {
-        match self.get_symbol(arg) {
+    pub fn get_list(&self, arg: &CascadeString) -> Vec<CascadeString> {
+        match self.get_symbol(arg.as_ref()) {
             Some(BindableObject::TypeList(tl)) => tl.iter().map(|t| t.name.clone()).collect(),
             Some(BindableObject::PermList(l)) | Some(BindableObject::ClassList(l)) => {
                 l.iter().map(|i| CascadeString::from(i as &str)).collect()
             }
             // Unwrap() is safe here because all of the get_name_or_string() None cases are handled
             // in get_list()
-            _ => vec![self.get_name_or_string(&CascadeString::from(arg)).unwrap()],
+            _ => {
+                vec![self.get_name_or_string(arg).unwrap()]
+            }
         }
     }
 
@@ -182,13 +184,13 @@ impl<'a> Context<'a> {
             }
             BindableObject::PermList(p) => BindableObject::PermList(
                 p.iter()
-                    .flat_map(|s| self.get_list(s.as_ref()))
+                    .flat_map(|s| self.get_list(&CascadeString::from(s.clone())))
                     .map(|s| s.to_string())
                     .collect(),
             ),
             BindableObject::ClassList(c) => BindableObject::ClassList(
                 c.iter()
-                    .flat_map(|s| self.get_list(s.as_ref()))
+                    .flat_map(|s| self.get_list(&CascadeString::from(s.clone())))
                     .map(|s| s.to_string())
                     .collect(),
             ),
@@ -196,7 +198,10 @@ impl<'a> Context<'a> {
                 match self.get_name_or_string(&CascadeString::from(&c as &str)) {
                     Some(s) => BindableObject::Class(s.to_string()),
                     None => BindableObject::ClassList(
-                        self.get_list(&c).iter().map(|s| s.to_string()).collect(),
+                        self.get_list(&CascadeString::from(&c as &str))
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
                     ),
                 }
             }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -256,7 +256,7 @@ fn call_to_av_rule<'a>(
     }
 
     for p in &perms {
-        class_perms.verify_permission(&class, p, context, file)?;
+        class_perms.verify_permission(&class, p, context, file, None)?;
     }
 
     let perms = ClassList::expand_perm_list(perms.iter().collect(), context);

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -256,7 +256,7 @@ fn call_to_av_rule<'a>(
     }
 
     for p in &perms {
-        class_perms.verify_permission(&class, p, context, file, None)?;
+        class_perms.verify_permission(&class, p, context, file)?;
     }
 
     let perms = ClassList::expand_perm_list(perms.iter().collect(), context);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,7 +960,7 @@ mod tests {
 
     #[test]
     fn bad_allow_rules_test() {
-        error_policy_test!("bad_allow.cas", 3, ErrorItem::Compile(_));
+        error_policy_test!("bad_allow.cas", 5, ErrorItem::Compile(_));
     }
 
     #[test]


### PR DESCRIPTION
Previously on object classes with "2" (e.g. capability2) if a permission was not part of that object class the compiler would always report the 2nd object class.  Now the correct object class from the cascade policy should be reported.

Issue #76