### PR TITLE
Handle full contexts correctly

### DIFF
--- a/data/expected_cil/filecon.cil
+++ b/data/expected_cil/filecon.cil
@@ -141,6 +141,7 @@
 (allow domain foo (file (read)))
 (filecon "/bin" file (system_u object_r foo ((s0) (s0))))
 (filecon "/bin" dir (system_u object_r foo ((s0) (s0))))
+(filecon "/bin/some_bin" file (system_u object_r foo ((s0) (s0))))
 (filecon "/dev/sda1" block (system_u object_r foo ((s0) (s0))))
 (filecon "/dev/tty.*" char (system_u object_r foo ((s0) (s0))))
 (filecon "/etc" any (system_u object_r foo ((s0) (s0))))

--- a/data/expected_cil/filecon.cil
+++ b/data/expected_cil/filecon.cil
@@ -142,6 +142,8 @@
 (filecon "/bin" file (system_u object_r foo ((s0) (s0))))
 (filecon "/bin" dir (system_u object_r foo ((s0) (s0))))
 (filecon "/bin/some_bin" file (system_u object_r foo ((s0) (s0))))
+(filecon "/bin/some_bin2" file (system_u object_r foo ((s0) (s0))))
+(filecon "/bin/some_bin3" file (system_u object_r foo ((s0) (s0))))
 (filecon "/dev/sda1" block (system_u object_r foo ((s0) (s0))))
 (filecon "/dev/tty.*" char (system_u object_r foo ((s0) (s0))))
 (filecon "/etc" any (system_u object_r foo ((s0) (s0))))

--- a/data/expected_cil/fs_context.cil
+++ b/data/expected_cil/fs_context.cil
@@ -144,6 +144,7 @@
 (fsuse trans tmpfs (system_u object_r foo ((s0) (s0))))
 (genfscon cgroup "/" (system_u object_r foo ((s0) (s0))))
 (genfscon proc "/" (system_u object_r foo ((s0) (s0))))
+(genfscon proc "/foo" (system_u object_r foo ((s0) (s0))))
 (sid kernel)
 (sidcontext kernel (system_u system_r kernel_sid ((s0) (s0))))
 (sid security)

--- a/data/policies/filecon.cas
+++ b/data/policies/filecon.cas
@@ -6,6 +6,7 @@ resource foo {
 	file_context("/etc/somesymlink", [lnk_file], this);
 	file_context("/var/somepipe", [fifo_file], this);
 	file_context("/var/somesocket", [sock_file], this);
+	file_context("/bin/some_bin", [file], system_u:object_r:foo:s0);
 	// Policies must include at least one av rule
 	allow(domain, foo, file, [read]);
 }

--- a/data/policies/filecon.cas
+++ b/data/policies/filecon.cas
@@ -7,6 +7,8 @@ resource foo {
 	file_context("/var/somepipe", [fifo_file], this);
 	file_context("/var/somesocket", [sock_file], this);
 	file_context("/bin/some_bin", [file], system_u:object_r:foo:s0);
+	file_context("/bin/some_bin2", [file], system_u:object_r:foo:s0-s0);
+	file_context("/bin/some_bin3", [file], system_u:object_r:foo:s0-s0:c0.c255);
 	// Policies must include at least one av rule
 	allow(domain, foo, file, [read]);
 }

--- a/data/policies/fs_context.cas
+++ b/data/policies/fs_context.cas
@@ -7,6 +7,8 @@ resource foo {
     fs_context(this, "proc", genfscon, "/");
     fs_context(this, "proc", genfscon, "/");
     fs_context(this, "cgroup", genfscon);
+    fs_context(system_u:object_r:foo, "proc", genfscon, "/foo");
+
     // TODO re-add when secilc check is in place
     // fs_context(this, "sysfs", genfscon, "/zap", [dir]);
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -146,6 +146,22 @@ impl From<&Port> for CascadeString {
     }
 }
 
+impl<const N: usize> From<&[&CascadeString; N]> for CascadeString {
+    fn from(cs_slice: &[&CascadeString; N]) -> Self {
+        let new_range = Self::slice_to_range(cs_slice);
+
+        let new_string = cs_slice
+            .iter()
+            .map(|c| c.as_ref())
+            .collect::<Vec<&str>>()
+            .join("");
+        CascadeString {
+            string: new_string,
+            range: new_range,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct PolicyFile {
     pub policy: Policy,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -425,7 +425,7 @@ fn call_to_fc_rules<'a>(
         )?,
         FunctionArgument::new(
             &DeclaredArgument {
-                param_type: CascadeString::from(constants::RESOURCE),
+                param_type: CascadeString::from("context"),
                 is_list_param: false,
                 name: CascadeString::from("file_context"),
                 default: None,
@@ -805,7 +805,7 @@ fn call_to_fsc_rules<'a>(
     let target_args = vec![
         FunctionArgument::new(
             &DeclaredArgument {
-                param_type: CascadeString::from(constants::RESOURCE),
+                param_type: CascadeString::from("context"),
                 is_list_param: false,
                 name: CascadeString::from("fs_label"),
                 default: None,

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -187,6 +187,11 @@ impl TypeInfo {
             return true;
         }
 
+        // Resources can evaluate to contexts, even though they don't technically inherit
+        if self.name == constants::RESOURCE && target.name == "context" {
+            return true;
+        }
+
         for parent in &self.inherits {
             let parent_typeinfo = match types.get(parent.as_ref()) {
                 Some(t) => t,
@@ -589,6 +594,9 @@ pub fn typeinfo_from_string<'a>(
         types.get("string")
     } else if s == "true" || s == "false" {
         types.get(constants::BOOLEAN)
+    } else if s.contains(':') && Context::try_from(s).is_ok() {
+        // a bare string could parse as a context, but should fall through
+        types.get("context")
     } else if class_perms.is_class(s) {
         types.get("obj_class")
     } else if class_perms.is_perm(s, context) {

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -232,6 +232,14 @@ Arg: Argument = {
 	Quoted_String => Argument::Quote(<>),
 	Port => Argument::Port(<>),
 	IPAddr => Argument::IpAddr(<>),
+	Context => Argument::Var(<>),
+}
+
+Context: CascadeString = {
+	// TODO: don't discard the mls range
+	<start: @L> <u: Symbol> ":" <r: Symbol> ":" <t: Symbol> <m: (":" <Symbol>)?> <end: @R> => {
+		CascadeString::new([u.as_ref(), r.as_ref(), t.as_ref()].join(":"), start..end)
+	}
 }
 
 Quoted_String: CascadeString = {

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -237,9 +237,40 @@ Arg: Argument = {
 
 Context: CascadeString = {
 	// TODO: don't discard the mls range
-	<start: @L> <u: Symbol> ":" <r: Symbol> ":" <t: Symbol> <m: (":" <Symbol>)?> <end: @R> => {
+	<start: @L> <u: Symbol> ":" <r: Symbol> ":" <t: Symbol> <m: (":" <MLS_Range>)?> <end: @R> => {
 		CascadeString::new([u.as_ref(), r.as_ref(), t.as_ref()].join(":"), start..end)
 	}
+}
+
+MLS_Range: CascadeString = {
+	<low: MLS_Level> <high: ("-"  <MLS_Level>)?> => {
+		match high {
+			Some(high) => CascadeString::from(&[&low, &CascadeString::from("-"), &high]),
+			None => low
+		}
+	}
+}
+
+MLS_Level: CascadeString = {
+	<s: Sensitivity> <c: (":" <Categories>)?> => {
+		match c {
+			Some(c) => CascadeString::from(&[&s, &CascadeString::from(":"), &c]),
+			None => s
+		}
+	}
+}
+
+Sensitivity: CascadeString = {
+	NameDecl,
+}
+
+Categories: CascadeString = {
+	Category,
+	<cs: Categories> "." <c: Category> => CascadeString::from(&[&cs, &CascadeString::from("."), &c]),
+}
+
+Category: CascadeString = {
+	NameDecl,
 }
 
 Quoted_String: CascadeString = {


### PR DESCRIPTION
Previously, only bare types were accepted as contexts.  This change allows the specification of the full context.