### PR TITLE
Remove obsolete/incorrect parse error order workaround

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,9 +319,6 @@ fn parse_policy(
     match parse_res {
         Ok(p) => {
             if !errors.is_empty() {
-                // Lalrpop returns errors in the reverse order they were found
-                // Reverse so that display is in source line order
-                parse_errors.reverse();
                 Err(parse_errors)
             } else {
                 Ok(p)
@@ -329,7 +326,6 @@ fn parse_policy(
         }
         Err(e) => {
             parse_errors.push(e);
-            parse_errors.reverse();
             Err(parse_errors)
         }
     }


### PR DESCRIPTION
What happened was:

1. We had a bug that our errors were reversed
2. I incorrectly thought it was a parser issue
3. I reversed the parse error order to address it
4. Some time later, I found and fixed the real bug
5. Now the reversing of parse errors reversed the newly correct order

Removing the parse error workaround should have all errors in the correct order now