### PR TITLE
Store classlist bindings as classlists

### DIFF
--- a/data/policies/let.cas
+++ b/data/policies/let.cas
@@ -22,3 +22,6 @@ domain foo {
 	allow(this, bar, file, nested_binding);
 	allow(foo, baz, file, write);
 }
+
+let class_list = [ file dir ];
+let cl2 = [ lnk_file class_list ];

--- a/src/context.rs
+++ b/src/context.rs
@@ -249,6 +249,8 @@ impl<'a> Context<'a> {
                 let arg_typeinstance = TypeInstance::new(&arg, variant, Some(file), &*self);
                 if variant.is_perm(type_map) {
                     BindableObject::PermList(v.iter().map(|s| s.to_string()).collect())
+                } else if variant.is_class(type_map) {
+                    BindableObject::ClassList(v.iter().map(|s| s.to_string()).collect())
                 } else {
                     BindableObject::TypeList(arg_typeinstance)
                 }


### PR DESCRIPTION
This doesn't test usage, because I'm not sure these are actually usable anywhere.  I think we probably will need to enhance AVRules to support lists of classes, but that's a separate/future problem.