### PR TITLE
Automatically coerce single arguments to lists in annotations

### DIFF
--- a/data/policies/derive.cas
+++ b/data/policies/derive.cas
@@ -33,7 +33,7 @@ resource custom_define inherits foo, bar {
 @derive([read], parents=*)
 resource union_all_parents inherits foo, bar {}
 
-@derive([read], parents=[foo])
+@derive([read], parents=foo)
 resource derive_from_foo inherits foo, bar {}
 
 @derive(*, *)

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2760,6 +2760,8 @@ fn validate_argument<'a>(
                 if arg_typeinfo.list_coercion
                     || matches!(arg_typeinfo.bound_type, BoundTypeInfo::List(_))
                     || arg.is_list_symbol(context)
+                    // Automatically coerce everything in annotations
+                    || context.in_annotation()
                 {
                     return validate_argument(
                         ArgForValidation::coerce_list(arg),


### PR DESCRIPTION
Annotations by design should be less strict about type checking