### PR TITLE
Bump github actions check from 3.5-rc3 to 3.5.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,10 +70,10 @@ jobs:
         # configurable policy versions, we should be able to successfully
         # test against 2.7-2.9
 
-        selinux-version: [ secilc-3.0, secilc-3.1, 3.2, 3.3, 3.4, 3.5-rc3 ]
+        selinux-version: [ secilc-3.0, secilc-3.1, 3.2, 3.3, 3.4, 3.5 ]
         rust-toolchain: [ stable ]
         include:
-          - selinux-version: '3.4'
+          - selinux-version: '3.5'
             rust-toolchain: nightly
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Since 3.5 is out of rcs, run our nightly checks against the latest and greatest.