### PR TITLE
Move derive_functions() to before prevalidate_functions()

### DIFF
--- a/data/expected_cil/derive.cil
+++ b/data/expected_cil/derive.cil
@@ -226,6 +226,7 @@
 (macro overwrite_one-some_associated_call ((type this) (type source)) (allow source this (dir (add_name))))
 (macro overwrite_one-write ((type this) (type source)) (allow source this (dir (write))))
 (macro some_child-domtrans ((type this) (type source) (type exec)) (typetransition source exec process this))
+(macro some_domain-call_derive_in_func ((type this) (type arg)) (call union_all_parents-read (union_all_parents arg)))
 (macro some_domain_parent-domtrans ((type this) (type source) (type exec)) (typetransition source exec process this))
 (macro to_associate-some_associated_call ((type this) (type source)) (allow source this (dir (add_name))) (allow source this (file (link))))
 (macro union_all_parents-read ((type this) (type source)) (allow source this (dir (read))) (allow source this (file (read))))

--- a/data/policies/derive.cas
+++ b/data/policies/derive.cas
@@ -52,6 +52,10 @@ domain some_domain {
 	name_diff_child.diff_name(this);
 
 	some_child.domtrans(this, derive_from_foo);
+
+	fn call_derive_in_func(domain arg) {
+		union_all_parents.read(arg);
+	}
 }
 
 @derive([some_associated_call], parents=*)


### PR DESCRIPTION
Originally, derive_functions() was located inside validate_functions() after the function bodies were validated.  The intent behind this was that we first ensure that the parents are correct, before generating a possibly incorrect child.  Unfortuantely, that doesn't actually work because the parents may call derived functions, and would then fail validation because the derived function doesn't exist yet.

In order to address this, pull derive_functions() out of validate_functions() and put it earlier.  With this change the derived functions get set for prevalidation (so they are castable), and are available when validating the bodies of all functions.

This requires moving all the rename logic from ValidatedStatements to Statements, which is the bulk of the diffstat on this commit.

It also has the implication that if we derive from a parent with a policy bug, we'll be deriving that policy bug into the derived child, so we ignore validation failures on derived children, unless there are no failures on other functions, in which case that's a Cascade bug and an internal error.  This is explained in detail in a comment in validate_functions().