### PR TITLE
Ignore clippy manual_flatten errors

### DIFF
--- a/.github/workflows/clippy.sh
+++ b/.github/workflows/clippy.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 VERSION=${1:-stable}
 
-rustup run ${VERSION} cargo clippy -- -A clippy::new_without_default --deny warnings
+rustup run ${VERSION} cargo clippy -- -A clippy::new_without_default -A clippy::manual_flatten --deny warnings
 
 # Suppress uninlined_format_args since assert! has a format! macro in it, which confuses clippy.
-rustup run ${VERSION} cargo clippy --tests -- -A clippy::new_without_default -A clippy::expect_fun_call -A clippy::uninlined_format_args
+rustup run ${VERSION} cargo clippy --tests -- -A clippy::new_without_default -A clippy::expect_fun_call -A clippy::uninlined_format_args -A clippy::manual_flatten

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1556,11 +1556,6 @@ fn dedup_inherited_annotations_one<'a>(
                 let left_diff = a.clone().difference(new.clone());
                 let right_diff = new.clone().difference(a.clone());
                 let intersect = a.intersection(new.clone());
-                // Clippy wants me to flatten the slice elements to skip the Nones.  It seems to me
-                // like that obscures the fact that we are conditionally inserting.  Maybe someone
-                // more fluent than me with iterator operations would disagree, but the logic here
-                // can get confusing, so I'd rather be explicit
-                #[allow(clippy::manual_flatten)]
                 for set in [left_diff, intersect] {
                     if let Some(set) = set {
                         out.push(set);


### PR DESCRIPTION
1. IMHO this suggestion typically makes the code less readable.  I find the interior if logic clearer than locating a flatten() in the middle of a chained collection of iterator calls and recalling the semantics of flatten() on an iterator.
2. The code suggestions provided by clippy to fix this issue do not always seem to compile.  I got #159 to compile and make clippy happen, and the flattening feels readable enough there, but the finally compiling code does not match clippy's suggestion, which was broken.

(In #159 I appeared to be running into something essentially similar to https://github.com/rust-lang/rust-clippy/issues/6893, but according to that issue, it was fixes a few years ago, so I'm not sure what's going on.  I might dig into it more, but as mentioned in point 1, I'm skeptical of the value of this check anyways)