### PR TITLE
[RFC] Add ability to do lookups on secondary indices in alias maps

### DIFF
--- a/src/alias_map.rs
+++ b/src/alias_map.rs
@@ -108,7 +108,7 @@ impl<T: Declared> AliasMap<T> {
 
     pub fn values_by_index(&self, index: String) -> Vec<&T> {
         if let Some(secondary) = self.secondary_indices.get(&index) {
-            secondary.iter().map(|v| self.get(v)).flatten().collect()
+            secondary.iter().filter_map(|v| self.get(v)).collect()
         } else {
             Vec::new()
         }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1276,6 +1276,13 @@ impl Declared for FunctionInfo<'_> {
     fn get_generic_name(&self) -> String {
         String::from("function")
     }
+
+    fn get_secondary_indices(&self) -> Vec<String> {
+        match self.class.get_name() {
+            Some(name) => vec![name.to_string()],
+            None => Vec::new(),
+        }
+    }
 }
 
 impl<'a> FunctionInfo<'a> {

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -172,6 +172,10 @@ impl Declared for TypeInfo {
     fn get_generic_name(&self) -> String {
         String::from("type")
     }
+
+    fn get_secondary_indices(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 impl TypeInfo {
@@ -327,7 +331,7 @@ impl TypeInfo {
     }
 
     pub fn defines_function(&self, virtual_function_name: &str, functions: &FunctionMap) -> bool {
-        for f in functions.values() {
+        for f in functions.values_by_index(self.name.to_string()) {
             if f.class == FunctionClass::Type(self) && f.name == virtual_function_name {
                 return true;
             }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -35,6 +35,10 @@ impl Declared for ValidatedModule<'_> {
     fn get_generic_name(&self) -> String {
         String::from("module")
     }
+
+    fn get_secondary_indices(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 impl<'a> Annotated for &ValidatedModule<'a> {
@@ -145,6 +149,9 @@ impl Declared for ValidatedMachine<'_> {
 
     fn get_generic_name(&self) -> String {
         String::from("machine")
+    }
+    fn get_secondary_indices(&self) -> Vec<String> {
+        Vec::new()
     }
 }
 


### PR DESCRIPTION
Use this to look up only functions from a specific type, rather than all functions