### PR TITLE
Remove dead BoundTypeInfo code

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -24,7 +24,7 @@ use crate::functions::{
 };
 use crate::internal_rep::{
     generate_sid_rules, get_type_annotations, validate_derive_args, Annotated, AnnotationInfo,
-    Associated, BoundTypeInfo, ClassList, Context, Sid, TypeInfo, TypeInstance, TypeMap,
+    Associated, ClassList, Context, Sid, TypeInfo, TypeInstance, TypeMap,
 };
 use crate::machine::{MachineMap, ModuleMap, ValidatedMachine, ValidatedModule};
 use crate::warning::{Warnings, WithWarnings};
@@ -252,7 +252,6 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
         declaration_file: None,
         annotations: BTreeSet::new(),
         decl: None,
-        bound_type: BoundTypeInfo::Unbound,
     };
 
     let security_sid = TypeInfo {
@@ -264,7 +263,6 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
         declaration_file: None,
         annotations: BTreeSet::new(),
         decl: None,
-        bound_type: BoundTypeInfo::Unbound,
     };
 
     let unlabeled_sid = TypeInfo {
@@ -276,7 +274,6 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
         declaration_file: None,
         annotations: BTreeSet::new(),
         decl: None,
-        bound_type: BoundTypeInfo::Unbound,
     };
 
     for sid in [kernel_sid, security_sid, unlabeled_sid] {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -24,7 +24,7 @@ use crate::error::{
 };
 use crate::internal_rep::{
     convert_class_name_if_this, type_name_from_string, typeinfo_from_string, Annotated,
-    AnnotationInfo, BoundTypeInfo, ClassList, Context, TypeInfo, TypeInstance, TypeMap,
+    AnnotationInfo, ClassList, Context, TypeInfo, TypeInstance, TypeMap,
 };
 use crate::obj_class::perm_list_to_sexp;
 use crate::warning::{Warning, Warnings, WithWarnings};
@@ -2655,7 +2655,6 @@ fn validate_argument<'a>(
             let arg_typeinfo = argument_to_typeinfo(&arg, types, class_perms, context, file)?;
             if target_argument.is_list_param {
                 if arg_typeinfo.list_coercion
-                    || matches!(arg_typeinfo.bound_type, BoundTypeInfo::List(_))
                     || arg.is_list_symbol(context)
                     // Automatically coerce everything in annotations
                     || context.in_annotation()

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -116,23 +116,6 @@ impl AnnotationInfo {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum BoundTypeInfo {
-    Single(String),
-    List(Vec<String>),
-    Unbound,
-}
-
-impl BoundTypeInfo {
-    pub fn get_contents_as_vec(&self) -> Vec<String> {
-        match self {
-            BoundTypeInfo::Single(s) => vec![s.clone()],
-            BoundTypeInfo::List(v) => v.clone(),
-            BoundTypeInfo::Unbound => Vec::new(),
-        }
-    }
-}
-
 pub trait Annotated {
     fn get_annotations(&self) -> std::collections::btree_set::Iter<AnnotationInfo>;
 }
@@ -148,7 +131,6 @@ pub struct TypeInfo {
     pub annotations: BTreeSet<AnnotationInfo>,
     // TODO: replace with Option<&TypeDecl>
     pub decl: Option<TypeDecl>,
-    pub bound_type: BoundTypeInfo,
 }
 
 impl PartialEq for TypeInfo {
@@ -224,31 +206,6 @@ impl TypeInfo {
                 declaration_file: Some(file.clone()), // TODO: Turn into reference
                 annotations: get_type_annotations(file, &td.annotations)?.inner(&mut warnings),
                 decl: Some(td),
-                bound_type: BoundTypeInfo::Unbound,
-            },
-            warnings,
-        ))
-    }
-
-    pub fn new_bound_type(
-        name: CascadeString,
-        variant: &str,
-        file: &SimpleFile<String, String>,
-        bound_type: BoundTypeInfo,
-        annotations: &Annotations,
-    ) -> Result<WithWarnings<TypeInfo>, CascadeErrors> {
-        let mut warnings = Warnings::new();
-        Ok(WithWarnings::new(
-            TypeInfo {
-                name,
-                inherits: vec![variant.into()], // Does this need to somehow grab the bound parents? Does this work for the single case?
-                is_virtual: true,               // Maybe?
-                is_trait: false,                // TODO: Allow bound traits?
-                list_coercion: annotations.has_annotation("makelist"),
-                declaration_file: Some(file.clone()),
-                annotations: get_type_annotations(file, annotations)?.inner(&mut warnings),
-                decl: None, // TODO: Where is this used?
-                bound_type,
             },
             warnings,
         ))
@@ -264,7 +221,6 @@ impl TypeInfo {
             declaration_file: None,
             annotations: BTreeSet::new(),
             decl: None,
-            bound_type: BoundTypeInfo::Unbound,
         }
     }
 


### PR DESCRIPTION
This was used for the special handling of global symbol binding.  That has sense been rolled into the generic symbol binding code, but the BoundTypeInfo code wasn't removed.  Only the Unbound variant was even being used, and this was just dead code.