### PR TITLE
Save the variant (domain or resource) of a type at creation time

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -24,7 +24,7 @@ use crate::functions::{
 };
 use crate::internal_rep::{
     generate_sid_rules, get_type_annotations, validate_derive_args, Annotated, AnnotationInfo,
-    Associated, ClassList, Context, Sid, TypeInfo, TypeInstance, TypeMap,
+    Associated, ClassList, Context, Sid, TypeInfo, TypeInstance, TypeMap, TypeVar,
 };
 use crate::machine::{MachineMap, ModuleMap, ValidatedMachine, ValidatedModule};
 use crate::warning::{Warnings, WithWarnings};
@@ -246,6 +246,7 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
     let kernel_sid = TypeInfo {
         name: CascadeString::from("kernel_sid"),
         inherits: vec![CascadeString::from(constants::DOMAIN)],
+        variant: TypeVar::Domain,
         is_virtual: false,
         is_trait: false,
         list_coercion: false,
@@ -257,6 +258,7 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
     let security_sid = TypeInfo {
         name: CascadeString::from("security_sid"),
         inherits: vec![CascadeString::from(constants::RESOURCE)],
+        variant: TypeVar::Resource,
         is_virtual: false,
         is_trait: false,
         list_coercion: false,
@@ -268,6 +270,7 @@ pub fn get_built_in_types_map() -> Result<TypeMap, CascadeErrors> {
     let unlabeled_sid = TypeInfo {
         name: CascadeString::from("unlabeled_sid"),
         inherits: vec![CascadeString::from(constants::RESOURCE)],
+        variant: TypeVar::Resource,
         is_virtual: false,
         is_trait: false,
         list_coercion: false,


### PR DESCRIPTION
Use it for later lookups.

Callgrind reports is_child_or_actual_type() as a hot spot in the code, with is_resource() being the main caller.  This change aims to short circuit these calls by precomputing whether a type is a domain or resource and simply returning that instead of recursive calling every time.

Full system compile     time:   [12.402 ms 12.423 ms 12.451 ms]
                        change: [-0.5263% -0.1668% +0.1473%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

Benchmarking Stress functions: Warming up for 3.0000 s Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 131.0s, or reduce sample count to 10.
Stress functions        time:   [1.3251 s 1.3334 s 1.3420 s]
                        change: [-5.0014% -4.2635% -3.4178%] (p = 0.00 < 0.05)
                        Performance has improved.