### PR TITLE
Fix internal error when validation fails on items in lists

### DIFF
--- a/data/error_policies/class_wrong.cas
+++ b/data/error_policies/class_wrong.cas
@@ -1,0 +1,3 @@
+domain dom {
+	allow(this, self, capability, [cap2_userns]);
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2763,12 +2763,12 @@ fn validate_argument<'a>(
             };
             let arg_typeinfo_vec = argument_to_typeinfo_vec(v, types, class_perms, context, file)?;
 
-            for arg in arg_typeinfo_vec {
-                if !arg.is_child_or_actual_type(target_argument.param_type, types) {
+            for (arg_ti, arg) in arg_typeinfo_vec.iter().zip(v.iter()) {
+                if !arg_ti.is_child_or_actual_type(target_argument.param_type, types) {
                     return Err(ErrorItem::make_compile_or_internal_error(
                         &format!("Expected type inheriting {}", target_ti.name),
                         file,
-                        arg.name.get_range(),
+                        arg.get_range(),
                         &format!("This type should inherit {}", target_ti.name),
                     ));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1536,4 +1536,9 @@ mod tests {
     fn initial_context_error_test() {
         error_policy_test!("initial_context.cas", 1, ErrorItem::Compile(_));
     }
+
+    #[test]
+    fn validation_fails_in_list_test() {
+        error_policy_test!("class_wrong.cas", 1, ErrorItem::Compile(_));
+    }
 }


### PR DESCRIPTION
The error message should be returned pointing to the actual string the user entered, not the name of the type we resolved it to, which may by built in or synthetic.  The non-list case had this correct, but the list case was wrong