### PR TITLE
Bump criterion version to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [dependencies]
 atty = "0.2"


### PR DESCRIPTION
This was actually already released when we added criterion, but the criterion user guide still pointed to 0.3.  Criterion updated their guide to mention 0.4 after the 0.4 release.

"Cargo bench" still works fine for our use case on the new version, and the measured performance numbers seem stable.