### PR TITLE
casc: Migrate from atty to is-terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ clap_mangen = "0.2"
 criterion = "0.3"
 
 [dependencies]
-atty = "0.2"
 backtrace = "0.3"
 clap = { version = "4", features = ["derive"] }
 codespan-reporting = "0.11"
 flate2 = "1"
+is-terminal = "0.4"
 lalrpop-util = "0.19"
 regex = "1"
 quick-xml = "0.27"

--- a/src/bin/casc/main.rs
+++ b/src/bin/casc/main.rs
@@ -9,6 +9,7 @@ use args::{Args, ColorArg};
 use package::build_package;
 
 use clap::Parser;
+use is_terminal::IsTerminal;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Error, ErrorKind, Write};
@@ -43,7 +44,7 @@ fn main() -> std::io::Result<()> {
     let color = match args.color {
         Some(ColorArg::Always) => ColorChoice::Always,
         Some(ColorArg::Auto) | None => {
-            if atty::is(atty::Stream::Stderr) {
+            if std::io::stderr().is_terminal() {
                 ColorChoice::Auto
             } else {
                 ColorChoice::Never


### PR DESCRIPTION
The atty crate appears abandoned and has a known security issue.  See https://rustsec.org/advisories/RUSTSEC-2021-0145 for more details on the issue.

The security issue is Windows only, and can only occur in certain situations under the control of our code, however, the crate is unmaintained and migration to a reasonable alternative is simple.