### PR TITLE
Refactor validate_functions() to remove the extra function map clone()

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -532,7 +532,6 @@ pub fn validate_functions<'a>(
     mut functions: FunctionMap<'a>,
     types: &'a TypeMap,
     class_perms: &'a ClassList,
-    functions_copy: &'a FunctionMap<'a>,
     context: &'a BlockContext<'a>,
 ) -> Result<WithWarnings<FunctionMap<'a>>, CascadeErrors> {
     let mut errors = CascadeErrors::new();
@@ -547,7 +546,7 @@ pub fn validate_functions<'a>(
     // block, and should have bindings in that block exposed
     for function in functions.values() {
         match function.validate_body(
-            functions_copy,
+            &functions,
             types,
             class_perms,
             context,
@@ -1085,15 +1084,8 @@ pub fn get_reduced_infos(
     prevalidate_functions(&mut new_func_map, &new_type_map)?;
 
     // Validate functions, including deriving functions from annotations
-    let new_func_map_copy = new_func_map.clone(); // In order to read function info while mutating
-    let new_func_map = validate_functions(
-        new_func_map,
-        &new_type_map,
-        classlist,
-        &new_func_map_copy,
-        global_context,
-    )?
-    .inner(&mut warnings);
+    let new_func_map = validate_functions(new_func_map, &new_type_map, classlist, global_context)?
+        .inner(&mut warnings);
 
     // Get the policy rules
     let mut new_policy_rules = get_policy_rules(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -551,7 +551,7 @@ pub fn validate_functions<'a>(
             context,
             function.declaration_file,
         ) {
-            Ok(ww) => ww.inner(&mut warnings),
+            Ok(ww) => function.body = Some(ww.inner(&mut warnings)),
             Err(e) => {
                 // If the function is derived and fails to validate one of two things have
                 // happened:

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1768,7 +1768,7 @@ impl<'a> FunctionInfo<'a> {
         class_perms: &'a ClassList,
         context: &BlockContext<'_>,
         file: &'a SimpleFile<String, String>,
-    ) -> Result<WithWarnings<()>, CascadeErrors> {
+    ) -> Result<WithWarnings<BTreeSet<ValidatedStatement<'a>>>, CascadeErrors> {
         let mut new_body = BTreeSet::new();
         let mut errors = CascadeErrors::new();
         let mut warnings = Warnings::new();
@@ -1791,8 +1791,7 @@ impl<'a> FunctionInfo<'a> {
         }
         let mut nv_rules = create_non_virtual_child_rules(&new_body, types);
         new_body.append(&mut nv_rules);
-        self.body = Some(new_body);
-        errors.into_result(WithWarnings::new((), warnings))
+        errors.into_result(WithWarnings::new(new_body, warnings))
     }
 
     // Generate the sexp for a synthetic alias function calling the real function

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1762,7 +1762,7 @@ impl<'a> FunctionInfo<'a> {
     }
 
     pub fn validate_body(
-        &mut self,
+        &self,
         functions: &'a FunctionMap<'a>,
         types: &'a TypeMap,
         class_perms: &'a ClassList,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1763,7 +1763,7 @@ impl<'a> FunctionInfo<'a> {
 
     pub fn validate_body(
         &self,
-        functions: &'a FunctionMap<'a>,
+        functions: &FunctionMap<'a>,
         types: &'a TypeMap,
         class_perms: &'a ClassList,
         context: &BlockContext<'_>,


### PR DESCRIPTION
Full system compile     time:   [12.382 ms 12.390 ms 12.399 ms]
                        change: [-1.2885% -0.9726% -0.6749%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking Stress functions: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 61.6s, or reduce sample count to 10.
Stress functions        time:   [610.72 ms 611.23 ms 611.73 ms]
                        change: [-7.6144% -7.5213% -7.4229%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
See complete justification in the commit message for the third commit.  Even if this didn't help performance, I think the fact that it sets us up to be able to refactor the API to become reentrant justifies it on its own.  That said, it does improve performance, and as the function map grows, I expect it to greatly reduce peak memory consumption.