### PR TITLE
Clean up type validation on lists

### DIFF
--- a/data/expected_cil/permissions.cil
+++ b/data/expected_cil/permissions.cil
@@ -150,6 +150,8 @@
 (allow foo foo (capability2 (mac_override)))
 (allow foo foo (capability2 (wake_alarm)))
 (allow foo read (file (read)))
+(allow foo read (file (read write setattr)))
+(allow foo read (file (write read getattr)))
 (allow foo self (bpf (map_create)))
 (allow foo self (capability2 (bpf)))
 (allow foo self (nscd (getpwd getgrp gethost)))

--- a/data/policies/permissions.cas
+++ b/data/policies/permissions.cas
@@ -11,6 +11,13 @@ domain foo {
 	allow(this, self, capability, bpf);
 	allow(this, self, bpf, map_create);
 	allow(this, read, file, read);
+
+	allow(this, read, file, some_perms);
+	allow(this, read, file, some_perms_other_order);
 }
 
 resource read {}
+
+let some_perms = [ write read getattr ];
+
+let some_perms_other_order = [ read write setattr ];

--- a/src/context.rs
+++ b/src/context.rs
@@ -247,7 +247,8 @@ impl<'a> Context<'a> {
                 let arg_typeinfo_vec =
                     argument_to_typeinfo_vec(v, type_map, class_perms, None, &*self, Some(file))?;
                 // TODO: classes
-                let variant = type_slice_to_variant(&arg_typeinfo_vec, type_map)?;
+                let variant =
+                    type_slice_to_variant(&arg_typeinfo_vec, arg.get_range(), file, type_map)?;
                 let arg_typeinstance = TypeInstance::new(&arg, variant, Some(file), &*self);
                 if variant.is_perm(type_map) {
                     BindableObject::PermList(v.iter().map(|s| s.to_string()).collect())

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2884,7 +2884,7 @@ impl<'a> ArgForValidation<'a> {
         ArgForValidation::List(vec)
     }
 
-    fn get_range(&self) -> Option<Range<usize>> {
+    pub fn get_range(&self) -> Option<Range<usize>> {
         match self {
             ArgForValidation::Var(s) => s.get_range(),
             ArgForValidation::List(v) => CascadeString::slice_to_range(v),


### PR DESCRIPTION
https://github.com/dburgener/cascade/pull/199 caused some of our type matching on lists to start to fail.  First clean up the error message when this happens, which was previously a TODO, then try harder to infer the right types.  As mentioned in the second commit message, this has us guess (possibly wrongly) on ambiguity.  For a post-0.1 future enhancement, we should detect ambiguity and require the developer to annotate.