### PR TITLE
Reenable makelist test

### DIFF
--- a/data/expected_cil/makelist.cil
+++ b/data/expected_cil/makelist.cil
@@ -143,6 +143,7 @@
 (roletype object_r unlabeled_sid)
 (typeattributeset resource (unlabeled_sid))
 (macro foo-foo_func ((type this) (type types)) (allow foo_dom foo (file (read))))
+(call foo-foo_func (foo foo))
 (sid kernel)
 (sidcontext kernel (system_u system_r kernel_sid ((s0) (s0))))
 (sid security)

--- a/data/policies/makelist.cas
+++ b/data/policies/makelist.cas
@@ -6,9 +6,5 @@ resource foo {
 }
 
 domain foo_dom {
-	// TODO: Reenable this
-	// The makelist portion of this works.  Unfortunately the part of compilation that translates lists into function arguments is broken.
-	// The current function implementation uses CIL macros under the hood, but it's not clear to me that they can take list arguments.
-	// This will need revisiting to clean up and ensure that lists are supported appropriately
-	//foo.foo_func(foo);
+	foo.foo_func(foo);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,17 +763,7 @@ mod tests {
 
     #[test]
     fn makelist_test() {
-        let policy_file = [POLICIES_DIR, "makelist.cas"].concat();
-
-        match compile_combined(vec![&policy_file]) {
-            Ok(_p) => {
-                // TODO: reenable.  See note in data/policies/makelist.cas
-                //assert!(p.contains(
-                //    "(call foo.foo_func"
-                //));
-            }
-            Err(e) => panic!("Makelist compilation failed with {}", e),
-        }
+        valid_policy_test("makelist.cas", &["(call foo-foo_func"], &[], 0);
     }
 
     #[test]


### PR DESCRIPTION
This test was disabled because of a bug around functions that has since been fixed