### PR TITLE
Drop unicode aware regexes

### DIFF
--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -330,11 +330,11 @@ IPv6: CascadeString = {
 
 // lexing precedence
 match {
-	r"\s*" => { },
+	r"[[:space:]]*" => { },
 	r"//[^\n\r]*[\n\r]*" => { },
-	r"(\d{1,3}\.){4}" => IPv4Regex,
+	r"([[:digit:]]{1,3}\.){4}" => IPv4Regex,
 	"::1" => IPv6Regex, // TODO
-	r"\d+" => PortRegex,
+	r"[[:digit:]]+" => PortRegex,
 } else {
 	_
 }


### PR DESCRIPTION
The regex tokens "\s" and "\d" are "unicode friendly" and could match whitespace and digit characters in other encodings than ASCII.  The result of including them in our grammar is that we then require regex support for the entirety of unicode, which builds a large table of unicode characters into our binary.

Replace \s and \d with their ASCII-only equivalents, [[:space:]] and [[:digit:]].

Note that this does not remove our unicode dependency by itself. Lalrpop 0.19.12 builds in unicode support by default because it doesn't yet expose the correct configuration knobs to users to enable or disable unicode support.  Once lalrpop 0.20 is released, then users that don't require unicode support will be able to disable it using a feature. This change moves Cascade to that "users that don't require unicode" group, so that we can take advantage of removing unicode support once Lalrpop exposes the correct knob.