### PR TITLE
Use the right file when validating default arguments

### DIFF
--- a/data/error_policies/invalid_default1.cas
+++ b/data/error_policies/invalid_default1.cas
@@ -1,0 +1,7 @@
+resource foo {
+	fn some_func(domain source, resource other=invalid_symbol) {
+		allow(source, other, file, read);
+	}
+}
+
+

--- a/data/error_policies/invalid_default2.cas
+++ b/data/error_policies/invalid_default2.cas
@@ -1,0 +1,4 @@
+domain dom {
+	foo.some_func(this);
+	allow(this, foo, file, write);
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2937,9 +2937,11 @@ pub fn validate_arguments<'a>(
     types: &'a TypeMap,
     class_perms: &ClassList,
     context: &BlockContext<'a>,
+    // The file we're validating in
+    // *NOT* the function definition file
     file: Option<&'a SimpleFile<String, String>>,
     // target_func_info and func_map will be None for built-ins
-    target_func_info: Option<&FunctionInfo>,
+    target_func_info: Option<&'a FunctionInfo>,
     func_map: Option<&FunctionMap>,
 ) -> Result<Vec<TypeInstance<'a>>, CascadeErrors> {
     // Member functions start with an invisible"this" argument.  If it does, skip it
@@ -3078,8 +3080,8 @@ pub fn validate_arguments<'a>(
             Some(arg) => arg,
             None => {
                 match &a.function_arg.default_value {
-                    // TODO: A compile error here may be confusing.  This should really
-                    // be validated earlier and then return an internal error here on failure
+                    // Note that `file` here is the *callers* file, but we're validating against a
+                    // value in the *declarers* file, so we use that instead
                     Some(v) => validate_argument(
                         ArgForValidation::from(v),
                         &None,
@@ -3087,7 +3089,7 @@ pub fn validate_arguments<'a>(
                         types,
                         class_perms,
                         context,
-                        file,
+                        target_func_info.and_then(|f| f.declaration_file),
                         call.is_avc(),
                         target_func_info,
                         func_map,
@@ -3287,6 +3289,7 @@ fn validate_argument<'a>(
             file,
         ));
     }
+
     match &arg {
         ArgForValidation::List(v) => {
             if !target_argument.is_list_param {


### PR DESCRIPTION
The previous code had a note about errors being potentially confusing, and boy was that note accurate.  We were mixing the caller's range with the declarer's file, and ending up pointing to a nonsense code point in the declarer's file, and claiming that a random portion of a comment wasn't a valid type.

The real solution here of course is to store file ids in CascadeStrings and then every CascadeString will have its file and range together as one chunk, but that's a pretty major rewrite, that will need to happen after 0.1