### PR TITLE
Don't have synthetic resources inherit statements from their parents

### DIFF
--- a/data/error_policies/error_in_associate.cas
+++ b/data/error_policies/error_in_associate.cas
@@ -1,0 +1,5 @@
+domain dom {
+	resource res {
+		file_context("/too/few/args");
+	}
+}

--- a/data/expected_cil/associate.cil
+++ b/data/expected_cil/associate.cil
@@ -297,6 +297,7 @@
 (allow nest_parent nest_parent-nest_resource (file (write)))
 (allow qux bar-bin (file (write)))
 (filecon "/some/path/to/file" file (system_u object_r nest_child-nest_resource ((s0) (s0))))
+(filecon "/some/path/to/file2" file (system_u object_r nest_child-nest_resource ((s0) (s0))))
 (sid kernel)
 (sidcontext kernel (system_u system_r kernel_sid ((s0) (s0))))
 (sid security)

--- a/data/policies/associate.cas
+++ b/data/policies/associate.cas
@@ -89,6 +89,7 @@ domain nest_child inherits nest_parent {
 	extend nest_resource {
 		allow(nest_child, this, file, ioctl);
 		file_context("/some/path/to/file", [file], system_u:object_r:nest_child.nest_resource:s0);
+		file_context("/some/path/to/file2", [file], this);
 	}
 
 	foo.tmp.not_an_associated_call();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1539,7 +1539,11 @@ fn create_synthetic_resource(
     dup_res_decl
         .expressions
         // If dup_res_decl is concrete, do not inherit virtual functions
-        .retain(|e| dup_res_is_virtual || !e.is_virtual_function());
+        // Never inherit statements
+        .retain(|e| {
+            (dup_res_is_virtual || !e.is_virtual_function())
+                && matches!(e, Expression::Decl(Declaration::Func(_)))
+        });
     if !global_exprs.insert(Expression::Decl(Declaration::Type(Box::new(
         dup_res_decl.clone(),
     )))) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1694,4 +1694,18 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn error_in_associate_test() {
+        // It's important that there be only 1 error and that it actually point at a code point
+        error_policy_test!("error_in_associate.cas", 1, ErrorItem::Compile(CompileError {
+            diagnostic: Diag {
+                inner: Diagnostic {
+                    message: msg,
+                    ..
+                }
+            },
+            ..
+        }) if msg.contains("file_context"));
+    }
 }


### PR DESCRIPTION
These would either be calls which apply anyways because of the parent child relationship, or things like file_context() that would error when inherited.

The real problem with these is that in certain scenarios they can result in the same statement being validated twice, once with a file and once without, and if it has an error, it is a problem