### PR TITLE
Swap this_casting and casting test names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -921,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    fn casting_test() {
+    fn this_casting_test() {
         valid_policy_test(
             "this_casting.cas",
             &["(macro daemon-runtime-read ((type this) (type source)) (allow source this (file (read))))",
@@ -932,7 +932,7 @@ mod tests {
     }
 
     #[test]
-    fn this_casting_test() {
+    fn casting_test() {
         valid_policy_test(
             "casting.cas",
             &["(allow foo foo (capability",


### PR DESCRIPTION
It looks like they became backwards in a bad merge resolution.  This commit makes the test function names refer to the files of the same name