### PR TITLE
Fix infinite loop bug(s) in recursion checking

### DIFF
--- a/data/error_policies/alias_conflict.cas
+++ b/data/error_policies/alias_conflict.cas
@@ -1,0 +1,16 @@
+virtual resource parent {
+	fn func(domain source) {
+		allow(source, this, file, read);
+	}
+}
+
+virtual resource foo inherits parent {}
+
+@alias(foo)
+virtual resource bar inherits parent {}
+
+domain dom {
+	allow(this, foo, file, read);
+}
+
+

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -578,15 +578,6 @@ pub fn prevalidate_functions(
         num_changed = determine_castable(functions, types);
     }
 
-    let (mut terminated_functions, mut nonterm_functions) = initialize_terminated(functions);
-
-    search_for_recursion(
-        &mut terminated_functions,
-        &mut nonterm_functions,
-        types,
-        functions,
-    )?;
-
     Ok(())
 }
 
@@ -693,6 +684,15 @@ fn postvalidate_functions(
 ) -> Result<(), CascadeErrors> {
     let mut deferrals = BTreeSet::new();
     let mut errors = CascadeErrors::new();
+
+    let (mut terminated_functions, mut nonterm_functions) = initialize_terminated(functions);
+
+    search_for_recursion(
+        &mut terminated_functions,
+        &mut nonterm_functions,
+        types,
+        functions,
+    )?;
 
     for (name, fi) in functions.iter() {
         for statement in fi.body.as_ref().unwrap_or(&BTreeSet::new()) {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -2015,7 +2015,11 @@ fn organize_type_map(types: &TypeMap) -> Result<Vec<&TypeInfo>, CascadeErrors> {
             ));
         }
         for t in &current_pass_types {
-            tmp_types.remove(&t.name.to_string());
+            if tmp_types.remove(&t.name.to_string()).is_none() {
+                // If remove failed, something has gone wrong, and we'll keep trying to remove this
+                // forever, so bail out
+                return Err(ErrorItem::Internal(InternalError::new()).into());
+            }
         }
         out.append(&mut current_pass_types);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -253,6 +253,24 @@ impl ErrorItem {
             (_, _) => ErrorItem::Internal(InternalError::new()),
         }
     }
+
+    // If it's a compile error, add an additional message, otherwise just return the error
+    pub fn maybe_add_additional_message(
+        self,
+        file: Option<&SimpleFile<String, String>>,
+        range: Option<Range<usize>>,
+        msg: &str,
+    ) -> Self {
+        if let ErrorItem::Compile(error) = self {
+            if let (Some(file), Some(range)) = (file, range) {
+                ErrorItem::Compile(error.add_additional_message(file, range, msg))
+            } else {
+                ErrorItem::Internal(InternalError::new())
+            }
+        } else {
+            self
+        }
+    }
 }
 
 impl From<ErrorItem> for Vec<ErrorItem> {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -3934,8 +3934,12 @@ pub fn search_for_recursion(
                 }
                 if is_term {
                     terminated_list.insert(function_info.get_cil_name());
-                    removed += 1;
-                    functions.remove(&function_info.get_cil_name());
+                    if functions.remove(&function_info.get_cil_name()) {
+                        removed += 1;
+                    } else {
+                        // We tried removing, but it was already gone.  Something has gone wrong
+                        return Err(ErrorItem::Internal(InternalError::new()).into());
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,8 @@ fn compile_machine_policies_internal(
     }
 
     // Generate type aliases
-    let t_aliases = compile::collect_aliases(type_map.iter());
+    let (t_aliases, alias_files) = compile::collect_aliases(type_map.iter());
+    type_map.validate_aliases(&t_aliases, &alias_files)?;
     type_map.set_aliases(t_aliases);
 
     for p in &policies {
@@ -236,7 +237,8 @@ fn compile_machine_policies_internal(
     compile::validate_modules(&policies, &type_map, &mut module_map)?;
 
     // Generate module aliases
-    let m_aliases = compile::collect_aliases(module_map.iter());
+    let (m_aliases, alias_files) = compile::collect_aliases(module_map.iter());
+    module_map.validate_aliases(&m_aliases, &alias_files)?;
     module_map.set_aliases(m_aliases);
 
     // Validate machines
@@ -1707,5 +1709,10 @@ mod tests {
             },
             ..
         }) if msg.contains("file_context"));
+    }
+
+    #[test]
+    fn alias_name_conflict_test() {
+        error_policy_test!("alias_conflict.cas", 1, ErrorItem::Compile(_));
     }
 }


### PR DESCRIPTION
The first commit is just a minor reordering to 1. Prepare to totally rewrite search_for_recursion() on top of the call tree added recently and 2. Delay the performance hit associated with it until later, in case there are errors earlier in compilation.

The second commit turns the infinite loop we were seeing on alias conflicts into an internal error.  This should help detect any future bugs in this area more easily.

The final commit is the real fix, which checks for alias conflicts and reports an error.  The error handling is an extremely awkward dance with a performance hit, as described in the commit message.  We should get everything back in terms of both code complexity and performance once we implement #219.