### PR TITLE
Fix issues reported by nightly version of clippy

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -130,7 +130,7 @@ impl PartialEq<CascadeString> for &str {
 
 impl PartialOrd for CascadeString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.string.partial_cmp(&other.string)
+        Some(self.cmp(other))
     }
 }
 
@@ -848,7 +848,7 @@ impl Hash for Port {
 // while ignoring the high
 impl PartialOrd for Port {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.low_port_num.partial_cmp(&other.low_port_num)
+        Some(self.cmp(other))
     }
 }
 
@@ -910,7 +910,7 @@ impl Hash for IpAddr {
 
 impl PartialOrd for IpAddr {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.inner.partial_cmp(&other.inner)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1773,11 +1773,8 @@ impl<'a> InheritedAnnotation<'a> {
             Some(intersect) => Some(InheritedAnnotation {
                 annotation: intersect,
                 parents: {
-                    let mut ret: Vec<&TypeInfo> = self
-                        .parents
-                        .into_iter()
-                        .chain(other.parents.into_iter())
-                        .collect();
+                    let mut ret: Vec<&TypeInfo> =
+                        self.parents.into_iter().chain(other.parents).collect();
                     ret.sort();
                     ret.dedup();
                     ret

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -57,7 +57,7 @@ impl<'a> Ord for ValidatedModule<'a> {
 
 impl<'a> PartialOrd for ValidatedModule<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.name.cmp(&other.name))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
* It is less error prone if explicit PartialOrd implmenentations call cmp() directly rather than reimplementing the same user logic in terms of partial_cmp()
* Don't use into_iter() on a function that takes IntoIterator