### PR TITLE
Update to criterion 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 
 [dependencies]
 backtrace = "0.3"


### PR DESCRIPTION
* Finally get obsolete, unmaintained atty crate out of our dependency tree
* Unify on clap 4 (we had 4, but criterion 0.4 had 3)