### PR TITLE
Do not use the lalrpop unicode feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = [ "selinux" ]
 
 [build-dependencies]
-lalrpop = "0.20"
+lalrpop = { version="0.20", default_features=false, features = ["lexer"] }
 clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 
@@ -23,7 +23,7 @@ clap = { version = "4", features = ["derive"] }
 codespan-reporting = "0.11"
 flate2 = "1"
 is-terminal = "0.4"
-lalrpop-util = "0.20"
+lalrpop-util = { version="0.20", default_features=false, features = ["lexer"] }
 quick-xml = "0.30"
 sexp = "1.1"
 tar = "0.4"


### PR DESCRIPTION
This feature enables support for unicode regexes, which we don't need. The extra unicode support bloats binary size and hurts performance