### PR TITLE
Don't skip non-existent whitespace

### DIFF
--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -330,7 +330,7 @@ IPv6: CascadeString = {
 
 // lexing precedence
 match {
-	r"[[:space:]]*" => { },
+	r"[[:space:]]+" => { },
 	r"//[^\n\r]*[\n\r]*" => { },
 	r"([[:digit:]]{1,3}\.){4}" => IPv4Regex,
 	"::1" => IPv6Regex, // TODO


### PR DESCRIPTION
The current code's skip pattern matches zero whitespace characters when skipping whitespace.  The result in the lalrpop lexer is that a zero-length match on no whitespace is found as a possible match.  In the common case where a longer match (the next token) was found, lalrpop discards the shorter match and returns the longer.  If no longer match was found, lalrpop has special handling to note that if only a zero-length match was found, that means no valid ones were.  So matching zero-length whitespace doesn't actually cause a problem, but it's also useless.

So write the expression we intend, which is to skip actual whitespace.