### PR TITLE
Use default-features in favor of default_features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = [ "selinux" ]
 
 [build-dependencies]
-lalrpop = { version="0.20", default_features=false, features = ["lexer"] }
+lalrpop = { version="0.20", default-features=false, features = ["lexer"] }
 clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 
@@ -23,7 +23,7 @@ clap = { version = "4", features = ["derive"] }
 codespan-reporting = "0.11"
 flate2 = "1"
 is-terminal = "0.4"
-lalrpop-util = { version="0.20", default_features=false, features = ["lexer"] }
+lalrpop-util = { version="0.20", default-features=false, features = ["lexer"] }
 quick-xml = "0.31"
 sexp = "1.1"
 tar = "0.4"


### PR DESCRIPTION
The _ variants of several Cargo fields will be deprecated in the 2024 edition.  Switch to the recommended - variants.

https://github.com/rust-lang/cargo/pull/13783