### PR TITLE
Move clippy overrides from the github actions code into the source

### DIFF
--- a/.github/workflows/clippy.sh
+++ b/.github/workflows/clippy.sh
@@ -4,7 +4,6 @@ set -e -u -o pipefail
 
 VERSION=${1:-stable}
 
-rustup run ${VERSION} cargo clippy -- -A clippy::new_without_default -A clippy::manual_flatten --deny warnings
+rustup run ${VERSION} cargo clippy -- --deny warnings
 
-# Suppress uninlined_format_args since assert! has a format! macro in it, which confuses clippy.
-rustup run ${VERSION} cargo clippy --tests -- -A clippy::new_without_default -A clippy::expect_fun_call -A clippy::uninlined_format_args -A clippy::manual_flatten
+rustup run ${VERSION} cargo clippy --tests

--- a/src/bin/audit2cascade.rs
+++ b/src/bin/audit2cascade.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
+#![allow(clippy::manual_flatten)]
+#![allow(clippy::new_without_default)]
 fn main() {
     println!("Hello World!");
 }

--- a/src/bin/casc/main.rs
+++ b/src/bin/casc/main.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
+#![allow(clippy::manual_flatten)]
+#![allow(clippy::new_without_default)]
 use selinux_cascade::error::{CascadeErrors, ErrorItem};
 use selinux_cascade::{compile_combined, compile_machine_policies, compile_machine_policies_all};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
+#![allow(clippy::manual_flatten)]
+#![allow(clippy::new_without_default)]
 #[macro_use]
 extern crate lalrpop_util;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_fun_call)]
 lalrpop_mod!(#[allow(clippy::all)] pub parser);
 
 use crate::error::{CompileError, Diag, ParseError};


### PR DESCRIPTION
This creates a predictable experience for developers running "cargo clippy" locally.

Note that "uninlined_format_args" was allowed due to a clippy bug which has since been fixed, so that exception is no longer needed.