### PR TITLE
Use lalrpop process_src() helper function

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ mod casc;
 
 fn main() -> std::io::Result<()> {
     // Generate parser
-    lalrpop::process_root().unwrap();
+    lalrpop::process_src().unwrap();
 
     // Generate man page
     // https://rust-cli.github.io/book/in-depth/docs.html


### PR DESCRIPTION
This alternative to process_root() was added in lalrpop 0.21 and searches only in the src directory for lalrpop files, rather than the entire project directory.