### PR TITLE
Address new mismatched_lifetime_syntaxes lint

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -275,7 +275,7 @@ impl AnnotationInfo {
 }
 
 pub trait Annotated {
-    fn get_annotations(&self) -> std::collections::btree_set::Iter<AnnotationInfo>;
+    fn get_annotations(&self) -> std::collections::btree_set::Iter<'_, AnnotationInfo>;
 }
 
 fn get_associate(

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2070,7 +2070,7 @@ impl<'a> FunctionInfo<'a> {
 }
 
 impl Annotated for &FunctionInfo<'_> {
-    fn get_annotations(&self) -> std::collections::btree_set::Iter<AnnotationInfo> {
+    fn get_annotations(&self) -> std::collections::btree_set::Iter<'_, AnnotationInfo> {
         self.annotations.iter()
     }
 }

--- a/src/internal_rep.rs
+++ b/src/internal_rep.rs
@@ -98,7 +98,7 @@ impl Ord for TypeInfo {
 }
 
 impl Annotated for &TypeInfo {
-    fn get_annotations(&self) -> std::collections::btree_set::Iter<AnnotationInfo> {
+    fn get_annotations(&self) -> std::collections::btree_set::Iter<'_, AnnotationInfo> {
         self.annotations.iter()
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -43,7 +43,7 @@ impl Declared for ValidatedModule<'_> {
 }
 
 impl Annotated for &ValidatedModule<'_> {
-    fn get_annotations(&self) -> std::collections::btree_set::Iter<AnnotationInfo> {
+    fn get_annotations(&self) -> std::collections::btree_set::Iter<'_, AnnotationInfo> {
         self.annotations.iter()
     }
 }


### PR DESCRIPTION
In rust 1.89, a lint is being added when lifetimes are referred to using different syntaxes across the args and return value.  We have a few instances where lifetimes are elided in the args and hidden in the return.  Elide in both cases to silence the lint.